### PR TITLE
Fix incorrect MQTT topics and behaviour for mock module script

### DIFF
--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -175,9 +175,7 @@ def publish(client, topic, data):
     print(topic, "--> ", json_data)
 
 
-def start_publishing(client, args):
-    print("publishing started...")
-
+def start_modules(args):
     # Initiate the correct modules when starting
     if args.id is None:
         for i in range(1, 4):
@@ -186,7 +184,7 @@ def start_publishing(client, args):
                 + "_" + str(round(time.time()))
                 + ".csv"
             })
-        print('started module 1\nstarted module 2\nstarted module 3')
+        print('\nstarted module 1\nstarted module 2\nstarted module 3')
 
     else:
         publish(client, "/v3/wireless-module/" + str(args.id) + "/start", {
@@ -197,12 +195,18 @@ def start_publishing(client, args):
         print('started module ' + str(args.id))
 
 
-    send_fake_data(client, args.time, args.rate, args.id)
-
+def stop_modules(args):
     for i in range(1, 4):
         publish(client, "/v3/wireless-module/" + str(i) + "/stop", {})
-    print('stopped module 1\nstopped module 2\nstopped module 3')
+    print('\nstopped module 1\nstopped module 2\nstopped module 3')
 
+
+def start_publishing(client, args):
+
+    print("\npublishing started...")
+    start_modules(args)
+    send_fake_data(client, args.time, args.rate, args.id)
+    stop_modules(args)
     print("\npublishing finished")
 
 

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -5,7 +5,7 @@ import paho.mqtt.client as mqtt
 from MockSensor import MockSensor
 
 parser = argparse.ArgumentParser(
-    description='MQTT wireless sensor test script that sends fake data',
+    description='MQTT wireless module test script that sends fake data',
     add_help=True)
 parser.add_argument(
     '-t', '--time', action='store', type=int,
@@ -21,8 +21,8 @@ parser.add_argument(
     default to localhost.""")
 parser.add_argument(
     '-i', '--id', action='store', type=int, default=None,
-    help="""Specify the sensor to produce fake data. eg. --id 1 specifies that
-    sensor 1 only produces data. If nothing is given all sensors will be
+    help="""Specify the module to produce fake data. eg. --id 1 specifies that
+    module 1 only produces data. If nothing is given all modules will be
     active.""")
 
 # Generate the fake sensors with average values
@@ -46,8 +46,8 @@ s_gps = MockSensor(("speed", 50),
                    ("course", 0))
 
 
-def send_fake_data(client, duration, rate, sensor_id):
-    """ Send artificial data over MQTT for each sensor chanel. Sends [rate] per
+def send_fake_data(client, duration, rate, module_id):
+    """ Send artificial data over MQTT for each module chanel. Sends [rate] per
     second for [duration] seconds"""
 
     start_time = round(time.time(), 2)
@@ -62,9 +62,9 @@ def send_fake_data(client, duration, rate, sensor_id):
         # it can be compaired with the the data read by the wireless logging
         # script
 
-        # Wireless Sensor 1 (Middle)
-        if sensor_id == 1 or sensor_id is None:
-            sensor_data = {
+        # Wireless module 1 (Middle)
+        if module_id == 1 or module_id is None:
+            module_data = {
                             "sensors": [
                                 {
                                     "type": "temperature",
@@ -82,15 +82,15 @@ def send_fake_data(client, duration, rate, sensor_id):
                           }
             battery_data = {"percentage": s_battery.get_value()}
 
-            sensor_topic = "v3/wireless-sensor/1/data"
-            battery_topic = "v3/wireless-sensor/1/battery"
+            module_topic = "v3/wireless-module/1/data"
+            battery_topic = "v3/wireless-module/1/battery"
 
-            publish(client, sensor_topic, sensor_data)
+            publish(client, module_topic, module_data)
             publish(client, battery_topic, battery_data)
 
-        # Wireless Sensor 2 (Back)
-        if sensor_id == 2 or sensor_id is None:
-            sensor_data = {
+        # Wireless module 2 (Back)
+        if module_id == 2 or module_id is None:
+            module_data = {
                             "sensors": [
                                 {
                                     "type": "co2",
@@ -116,15 +116,15 @@ def send_fake_data(client, duration, rate, sensor_id):
                           }
             battery_data = {"percentage": s_battery.get_value()}
 
-            sensor_topic = "v3/wireless-sensor/2/data"
-            battery_topic = "v3/wireless-sensor/2/battery"
+            module_topic = "v3/wireless-module/2/data"
+            battery_topic = "v3/wireless-module/2/battery"
 
-            publish(client, sensor_topic, sensor_data)
+            publish(client, module_topic, module_data)
             publish(client, battery_topic, battery_data)
 
-        # Wireless Sensor 3 (Front)
-        if sensor_id == 3 or sensor_id is None:
-            sensor_data = {
+        # Wireless module 3 (Front)
+        if module_id == 3 or module_id is None:
+            module_data = {
                             "sensors": [
                                 {
                                     "type": "co2",
@@ -142,10 +142,10 @@ def send_fake_data(client, duration, rate, sensor_id):
                           }
             battery_data = {"percentage": s_battery.get_value()}
 
-            sensor_topic = "v3/wireless-sensor/3/data"
-            battery_topic = "v3/wireless-sensor/3/battery"
+            module_topic = "v3/wireless-module/3/data"
+            battery_topic = "v3/wireless-module/3/battery"
 
-            publish(client, sensor_topic, sensor_data)
+            publish(client, module_topic, module_data)
             publish(client, battery_topic, battery_data)
 
         time.sleep(1/rate)

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -12,8 +12,8 @@ parser.add_argument(
     default=float('Inf'), help="""Length of time to send data in seconds
     (duration). If nothing is selected it will continuously send out data.""")
 parser.add_argument(
-    '-r', '--rate', action='store', type=float, default=1,
-    help="""Rate of data in data sent per second. Default is 1 data pack sent
+    '-r', '--rate', action='store', type=float, default=5,
+    help="""Rate of data in data sent per second. Default is 5 data pack sent
     per second.""")
 parser.add_argument(
     '--host', action='store', type=str, default="localhost",

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -181,14 +181,18 @@ def start_publishing(client, args):
     # Initiate the correct modules
     if args.id is None:
         print('started module 1\nstarted module 2\nstarted module 3')
-        for i in range(1,4):
+        for i in range(1, 4):
             publish(client, "/v3/wireless-module/" + str(i) + "/start", {
-                "filename": "M" + str(i) + "_" + str(round(time.time())) + ".csv"
+                "filename": "M" + str(i)
+                + "_" + str(round(time.time()))
+                + ".csv"
             })
     else:
         print('started module ' + str(args.id))
         publish(client, "/v3/wireless-module/" + str(i) + "/start", {
-            "filename": "M" + str(args.id) + "_" + str(round(time.time())) + ".csv"
+            "filename": "M" + str(args.id)
+            + "_" + str(round(time.time()))
+            + ".csv"
         })
 
     send_fake_data(client, args.time, args.rate, args.id)

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -171,7 +171,9 @@ def publish(client, topic, data):
 
 
 def start_modules(args):
-    # Initiate the correct modules when starting
+    """ Send the a fake filename on the start channel to start the appropriate
+    module"""
+
     if args.id is None:
         for i in range(1, 4):
             publish(client, "/v3/wireless-module/" + str(i) + "/start", {
@@ -191,6 +193,9 @@ def start_modules(args):
 
 
 def stop_modules(args):
+    """ Sends a null message on the stop channel for all of the modules to
+    stop"""
+
     print()  # Newline for clarity
     for i in range(1, 4):
         publish(client, "/v3/wireless-module/" + str(i) + "/stop", {})
@@ -198,7 +203,6 @@ def stop_modules(args):
 
 
 def start_publishing(client, args):
-
     print("\npublishing started...")
     start_modules(args)
     send_fake_data(client, args.time, args.rate, args.id)

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -70,6 +70,7 @@ def send_fake_data(client, duration, rate, module_id):
 
         # Wireless module 1 (Middle)
         if module_id == 1 or module_id is None:
+            module_num = 1
             module_data = {
                             "sensors": [
                                 {
@@ -86,7 +87,10 @@ def send_fake_data(client, duration, rate, module_id):
                                 }
                              ]
                           }
-            battery_data = {"percentage": s_battery.get_value()}
+            battery_data = {
+                "module-id": module_num,
+                "percentage": s_battery.get_value()
+            }
 
             module_topic = "/v3/wireless-module/1/data"
             battery_topic = "/v3/wireless-module/1/battery"
@@ -121,7 +125,10 @@ def send_fake_data(client, duration, rate, module_id):
                                 }
                              ]
                           }
-            battery_data = {"percentage": s_battery.get_value()}
+            battery_data = {
+                "module-id": module_num,
+                "percentage": s_battery.get_value()
+            }
 
             module_topic = "/v3/wireless-module/2/data"
             battery_topic = "/v3/wireless-module/2/battery"
@@ -148,7 +155,10 @@ def send_fake_data(client, duration, rate, module_id):
                                 }
                              ]
                           }
-            battery_data = {"percentage": s_battery.get_value()}
+            battery_data = {
+                "module-id": module_num,
+                "percentage": s_battery.get_value()
+            }
 
             module_topic = "/v3/wireless-module/3/data"
             battery_topic = "/v3/wireless-module/3/battery"

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -12,8 +12,8 @@ parser.add_argument(
     default=float('Inf'), help="""Length of time to send data in seconds
     (duration). If nothing is selected it will continuously send out data.""")
 parser.add_argument(
-    '-r', '--rate', action='store', type=float, default=5,
-    help="""Rate of data in data sent per second. Default is 5 data pack sent
+    '-r', '--rate', action='store', type=float, default=1,
+    help="""Rate of data in data sent per second. Default is 1 data pack sent
     per second.""")
 parser.add_argument(
     '--host', action='store', type=str, default="localhost",

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -59,11 +59,23 @@ def send_fake_data(client, duration, rate, module_id):
         current_time = round(time.time(), 2)
         total_time = round(current_time - start_time, 2)
         publish_battery = (battery_counter * battery_duration) <= total_time
-        print()  # Newline for clarity
 
         # TODO: create function that outputs the wireless data output so that
         # it can be compaired with the the data read by the wireless logging
         # script
+
+        def publish_data_and_battery(module_num):
+            battery_data = {
+                "module-id": module_num,
+                "percentage": s_battery.get_value()
+            }
+
+            module_topic = "/v3/wireless-module/"+str(module_num)+"/data"
+            battery_topic = "/v3/wireless-module/"+str(module_num)+"/battery"
+
+            publish(client, module_topic, module_data)
+            if publish_battery:
+                publish(client, battery_topic, battery_data)
 
         if publish_battery:
             battery_counter += 1
@@ -87,20 +99,11 @@ def send_fake_data(client, duration, rate, module_id):
                                 }
                              ]
                           }
-            battery_data = {
-                "module-id": module_num,
-                "percentage": s_battery.get_value()
-            }
-
-            module_topic = "/v3/wireless-module/1/data"
-            battery_topic = "/v3/wireless-module/1/battery"
-
-            publish(client, module_topic, module_data)
-            if publish_battery:
-                publish(client, battery_topic, battery_data)
+            publish_data_and_battery(module_num)
 
         # Wireless module 2 (Back)
         if module_id == 2 or module_id is None:
+            module_num = 2
             module_data = {
                             "sensors": [
                                 {
@@ -125,20 +128,11 @@ def send_fake_data(client, duration, rate, module_id):
                                 }
                              ]
                           }
-            battery_data = {
-                "module-id": module_num,
-                "percentage": s_battery.get_value()
-            }
-
-            module_topic = "/v3/wireless-module/2/data"
-            battery_topic = "/v3/wireless-module/2/battery"
-
-            publish(client, module_topic, module_data)
-            if publish_battery:
-                publish(client, battery_topic, battery_data)
+            publish_data_and_battery(module_num)
 
         # Wireless module 3 (Front)
         if module_id == 3 or module_id is None:
+            module_num = 3
             module_data = {
                             "sensors": [
                                 {
@@ -155,18 +149,9 @@ def send_fake_data(client, duration, rate, module_id):
                                 }
                              ]
                           }
-            battery_data = {
-                "module-id": module_num,
-                "percentage": s_battery.get_value()
-            }
+            publish_data_and_battery(module_num)
 
-            module_topic = "/v3/wireless-module/3/data"
-            battery_topic = "/v3/wireless-module/3/battery"
-
-            publish(client, module_topic, module_data)
-            if publish_battery:
-                publish(client, battery_topic, battery_data)
-
+        print()  # Newline for clarity
         time.sleep(1/rate)
 
 
@@ -194,7 +179,7 @@ def start_modules(args):
                 + "_" + str(round(time.time()))
                 + ".csv"
             })
-        print('\nstarted module 1\nstarted module 2\nstarted module 3')
+        print('\nstarted module 1\nstarted module 2\nstarted module 3\n')
 
     else:
         publish(client, "/v3/wireless-module/" + str(args.id) + "/start", {
@@ -202,10 +187,11 @@ def start_modules(args):
             + "_" + str(round(time.time()))
             + ".csv"
         })
-        print('started module ' + str(args.id))
+        print('started module ' + str(args.id) + '\n')
 
 
 def stop_modules(args):
+    print()  # Newline for clarity
     for i in range(1, 4):
         publish(client, "/v3/wireless-module/" + str(i) + "/stop", {})
     print('\nstopped module 1\nstopped module 2\nstopped module 3')

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -52,8 +52,8 @@ def send_fake_data(client, duration, rate, module_id):
 
     start_time = round(time.time(), 2)
     total_time = 0
-    battery_duration = 5 * 60  # To be run every 5min
-    battery_counter = 0
+    battery_duration = 5 * 60   # Battery info to be published every 5min
+    battery_counter = 0         # Battery counter to determine when to publish
 
     while total_time < duration:
         current_time = round(time.time(), 2)
@@ -64,6 +64,9 @@ def send_fake_data(client, duration, rate, module_id):
         # TODO: create function that outputs the wireless data output so that
         # it can be compaired with the the data read by the wireless logging
         # script
+
+        if publish_battery:
+            battery_counter += 1
 
         # Wireless module 1 (Middle)
         if module_id == 1 or module_id is None:
@@ -89,10 +92,8 @@ def send_fake_data(client, duration, rate, module_id):
             battery_topic = "/v3/wireless-module/1/battery"
 
             publish(client, module_topic, module_data)
-
             if publish_battery:
                 publish(client, battery_topic, battery_data)
-                battery_counter += 1
 
         # Wireless module 2 (Back)
         if module_id == 2 or module_id is None:
@@ -126,10 +127,8 @@ def send_fake_data(client, duration, rate, module_id):
             battery_topic = "/v3/wireless-module/2/battery"
 
             publish(client, module_topic, module_data)
-
             if publish_battery:
                 publish(client, battery_topic, battery_data)
-                battery_counter += 1
 
         # Wireless module 3 (Front)
         if module_id == 3 or module_id is None:
@@ -155,10 +154,8 @@ def send_fake_data(client, duration, rate, module_id):
             battery_topic = "/v3/wireless-module/3/battery"
 
             publish(client, module_topic, module_data)
-
             if publish_battery:
                 publish(client, battery_topic, battery_data)
-                battery_counter += 1
 
         time.sleep(1/rate)
 
@@ -180,7 +177,22 @@ def publish(client, topic, data):
 
 def start_publishing(client, args):
     print("publishing started...")
+
+    # Initiate the correct modules
+    if args.id is None:
+        print('started module 1\nstarted module 2\nstarted module 3')
+        for i in range(1,4):
+            publish(client, "/v3/wireless-module/" + str(i) + "/start", {
+                "filename": "M" + str(i) + "_" + str(round(time.time())) + ".csv"
+            })
+    else:
+        print('started module ' + str(args.id))
+        publish(client, "/v3/wireless-module/" + str(i) + "/start", {
+            "filename": "M" + str(args.id) + "_" + str(round(time.time())) + ".csv"
+        })
+
     send_fake_data(client, args.time, args.rate, args.id)
+
     print("publishing finished")
 
 

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -52,11 +52,14 @@ def send_fake_data(client, duration, rate, module_id):
 
     start_time = round(time.time(), 2)
     total_time = 0
+    battery_duration = 5 * 60  # To be run every 5min
+    battery_counter = 0
 
     while total_time < duration:
         current_time = round(time.time(), 2)
         total_time = round(current_time - start_time, 2)
-        print()     # Newline for clarity
+        publish_battery = (battery_counter * battery_duration) <= total_time
+        print()  # Newline for clarity
 
         # TODO: create function that outputs the wireless data output so that
         # it can be compaired with the the data read by the wireless logging
@@ -86,7 +89,10 @@ def send_fake_data(client, duration, rate, module_id):
             battery_topic = "/v3/wireless-module/1/battery"
 
             publish(client, module_topic, module_data)
-            publish(client, battery_topic, battery_data)
+
+            if publish_battery:
+                publish(client, battery_topic, battery_data)
+                battery_counter += 1
 
         # Wireless module 2 (Back)
         if module_id == 2 or module_id is None:
@@ -120,7 +126,10 @@ def send_fake_data(client, duration, rate, module_id):
             battery_topic = "/v3/wireless-module/2/battery"
 
             publish(client, module_topic, module_data)
-            publish(client, battery_topic, battery_data)
+
+            if publish_battery:
+                publish(client, battery_topic, battery_data)
+                battery_counter += 1
 
         # Wireless module 3 (Front)
         if module_id == 3 or module_id is None:
@@ -146,7 +155,10 @@ def send_fake_data(client, duration, rate, module_id):
             battery_topic = "/v3/wireless-module/3/battery"
 
             publish(client, module_topic, module_data)
-            publish(client, battery_topic, battery_data)
+
+            if publish_battery:
+                publish(client, battery_topic, battery_data)
+                battery_counter += 1
 
         time.sleep(1/rate)
 

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -180,24 +180,30 @@ def start_publishing(client, args):
 
     # Initiate the correct modules when starting
     if args.id is None:
-        print('started module 1\nstarted module 2\nstarted module 3')
         for i in range(1, 4):
             publish(client, "/v3/wireless-module/" + str(i) + "/start", {
                 "filename": "M" + str(i)
                 + "_" + str(round(time.time()))
                 + ".csv"
             })
+        print('started module 1\nstarted module 2\nstarted module 3')
+
     else:
-        print('started module ' + str(args.id))
         publish(client, "/v3/wireless-module/" + str(args.id) + "/start", {
             "filename": "M" + str(args.id)
             + "_" + str(round(time.time()))
             + ".csv"
         })
+        print('started module ' + str(args.id))
+
 
     send_fake_data(client, args.time, args.rate, args.id)
 
-    print("publishing finished")
+    for i in range(1, 4):
+        publish(client, "/v3/wireless-module/" + str(i) + "/stop", {})
+    print('stopped module 1\nstopped module 2\nstopped module 3')
+
+    print("\npublishing finished")
 
 
 def on_connect(client, userdata, flags, rc):

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -178,7 +178,7 @@ def publish(client, topic, data):
 def start_publishing(client, args):
     print("publishing started...")
 
-    # Initiate the correct modules
+    # Initiate the correct modules when starting
     if args.id is None:
         print('started module 1\nstarted module 2\nstarted module 3')
         for i in range(1, 4):
@@ -189,7 +189,7 @@ def start_publishing(client, args):
             })
     else:
         print('started module ' + str(args.id))
-        publish(client, "/v3/wireless-module/" + str(i) + "/start", {
+        publish(client, "/v3/wireless-module/" + str(args.id) + "/start", {
             "filename": "M" + str(args.id)
             + "_" + str(round(time.time()))
             + ".csv"

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -82,8 +82,8 @@ def send_fake_data(client, duration, rate, module_id):
                           }
             battery_data = {"percentage": s_battery.get_value()}
 
-            module_topic = "v3/wireless-module/1/data"
-            battery_topic = "v3/wireless-module/1/battery"
+            module_topic = "/v3/wireless-module/1/data"
+            battery_topic = "/v3/wireless-module/1/battery"
 
             publish(client, module_topic, module_data)
             publish(client, battery_topic, battery_data)
@@ -116,8 +116,8 @@ def send_fake_data(client, duration, rate, module_id):
                           }
             battery_data = {"percentage": s_battery.get_value()}
 
-            module_topic = "v3/wireless-module/2/data"
-            battery_topic = "v3/wireless-module/2/battery"
+            module_topic = "/v3/wireless-module/2/data"
+            battery_topic = "/v3/wireless-module/2/battery"
 
             publish(client, module_topic, module_data)
             publish(client, battery_topic, battery_data)
@@ -142,8 +142,8 @@ def send_fake_data(client, duration, rate, module_id):
                           }
             battery_data = {"percentage": s_battery.get_value()}
 
-            module_topic = "v3/wireless-module/3/data"
-            battery_topic = "v3/wireless-module/3/battery"
+            module_topic = "/v3/wireless-module/3/data"
+            battery_topic = "/v3/wireless-module/3/battery"
 
             publish(client, module_topic, module_data)
             publish(client, battery_topic, battery_data)

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -174,6 +174,10 @@ def start_modules(args):
     """ Send the a fake filename on the start channel to start the appropriate
     module"""
 
+    # TODO: Add posibility to make modules by importing a file or generating
+    # random modules. There should be a posibility to have many different
+    # modules.
+
     if args.id is None:
         for i in range(1, 4):
             publish(client, "/v3/wireless-module/" + str(i) + "/start", {

--- a/Raspi/Test/mock_wireless_module.py
+++ b/Raspi/Test/mock_wireless_module.py
@@ -175,8 +175,7 @@ def start_modules(args):
     module"""
 
     # TODO: Add posibility to make modules by importing a file or generating
-    # random modules. There should be a posibility to have many different
-    # modules.
+    # random modules. The modules should not be hard coded to this script.
 
     if args.id is None:
         for i in range(1, 4):


### PR DESCRIPTION
## Description

This fixes the mock script to properly mimic the behavior of the real modules. 

- Topic names are now finally correct
- Fake battery readout only gets sent every 5 minutes instead of 5 times a second
- When started the start channel will be sent a fake file name that comprises of the sensor name and time
- When ending the stop channel will be sent blank data

## Screenshots

<img width="624" alt="Screen Shot 2020-01-21 at 5 24 42 pm" src="https://user-images.githubusercontent.com/23159604/72780417-eee2ca00-3c72-11ea-8dd6-cfe1e0273258.png">

The battery data only gets sent at the start once instead of each time with the data.


## Steps to Test

For 5 seconds of data (mosquitto has to be running locally)
python mock_wireless_module.py -t 5
