### PR TITLE
Wireless Module Logger

### DIFF
--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -23,7 +23,7 @@ class DataToTempCSV:
             self.type = "BATTERY"
             self.parse_module_battery()
 
-        elif msg.topic == "v3/wireless-sensor/battery/low":
+        elif msg.topic == "/v3/wireless-module/battery/low":
             self.type = "BATTERY_LOW"
             self.parse_low_battery()
 

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -12,35 +12,6 @@ def DataToTempCSV(msg, module_start_time, module_id):
     module_start_time:          Start time of the module (datetime obj)
     """
 
-    data_dict = {}             # Data to be output to a temp CSV
-
-    # Decode the data as utf-8 and load into python dict
-    module_data = msg.payload.decode("utf-8")
-    module_data = json.loads(module_data)
-
-    # Determine which type of data to parse
-    if msg.topic.endswith("data"):
-        type = "DATA"
-        parse_module_data()
-
-    elif msg.topic.endswith("battery"):
-        type = "BATTERY"
-        parse_module_battery()
-
-    elif msg.topic == "/v3/wireless-module/battery/low":
-        type = "BATTERY_LOW"
-        # Nothing to parse
-
-    # Find the difference in seconds to when the recording was started and
-    # when the data was recieved.
-    time_delta = datetime.now() - module_start_time
-    time_delta = time_delta.total_seconds()
-    time_dict_key = f"{module_id}_{type}_TIME"
-    data_dict[time_dict_key] = time_delta
-
-    # Add or create the temp CSV to store the data
-    self.make_temp_csv()
-
     def parse_module_data(self):
         """ Parses the module data if it is from the sensors """
 
@@ -87,3 +58,32 @@ def DataToTempCSV(msg, module_start_time, module_id):
 
             # Append the data onto the temporary file
             csv_writer.writerow(self.data_dict)
+
+    data_dict = {}  # Data to be output to a temp CSV
+
+    # Decode the data as utf-8 and load into python dict
+    module_data = msg.payload.decode("utf-8")
+    module_data = json.loads(module_data)
+
+    # Determine which type of data to parse
+    if msg.topic.endswith("data"):
+        type = "DATA"
+        parse_module_data()
+
+    elif msg.topic.endswith("battery"):
+        type = "BATTERY"
+        parse_module_battery()
+
+    elif msg.topic == "/v3/wireless-module/battery/low":
+        type = "BATTERY_LOW"
+        # Nothing to parse
+
+    # Find the difference in seconds to when the recording was started and
+    # when the data was recieved.
+    time_delta = datetime.now() - module_start_time
+    time_delta = time_delta.total_seconds()
+    time_dict_key = f"{module_id}_{type}_TIME"
+    data_dict[time_dict_key] = time_delta
+
+    # Add or create the temp CSV to store the data
+    self.make_temp_csv(module_data)

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -35,7 +35,8 @@ class DataToTempCSV:
         # when the data was recieved.
         self.time_delta = datetime.now() - self.module_start_time
         self.time_delta = self.time_delta.total_seconds()
-        self.data_dict[self.module_id+"_"+self.type+"_TIME"] = self.time_delta
+        time_dict_key = f"{self.module_id}_{self.type}_TIME"
+        self.data_dict[time_dict_key] = self.time_delta
 
         # Add or create the temp CSV to store the data
         self.make_temp_csv()
@@ -52,9 +53,8 @@ class DataToTempCSV:
 
             if isinstance(sensor_value, dict):
                 # For nested sensor values
-                for sub_sensor in sensor_value.keys():
+                for (sub_sensor, sub_sensor_value) in sensor_value.items():
                     sub_sensor_name = sensor_name + '_' + sub_sensor
-                    sub_sensor_value = sensor_value[sub_sensor]
                     self.data_dict[sub_sensor_name] = sub_sensor_value
             else:
                 self.data_dict[sensor_name] = sensor_value

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime
 import os
 import csv
-# mosquitto_pub -t "/v3/wireless-module/battery/low" -m '{"module-id": 2}'
+
 
 class DataToTempCSV:
     """ Single use object to parse the MQTT data and convert it to a temporary
@@ -66,11 +66,15 @@ class DataToTempCSV:
             self.module_data["percentage"]
 
     def make_temp_csv(self):
+        """ Makes a temporary CSV file that is hidden and is in the form of
+        .~temp_<filename>.csv in the current directory"""
+
         # Ensures that the temp file is in the same folder as the script
         current_dir = os.path.dirname(__file__)
         temp_filename = str('.~temp_' + self.module_id+'_'+self.type + '.csv')
         temp_file_path = os.path.join(current_dir, temp_filename)
 
+        # Find the names for the CSV columns
         column_names = []
         for key in self.data_dict.keys():
             column_names.append(key)

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -6,9 +6,6 @@ import csv
 
 class DataToTempCSV:
     def __init__(self, msg, module_id="ALL"):
-        # TODO: FIX THE TOPICS TO SPEC
-        # TODO: ADD THE CORRECT '/'
-
         self.msg = msg
         self.data_dict = {}
         self.module_id = module_id
@@ -36,7 +33,6 @@ class DataToTempCSV:
 
         # Add or create the temp CSV to store the data
         self.make_temp_csv()
-        print("recorded -->", self.data_dict)
 
     def parse_module_data(self):
         # Retrieve sensor data from python dict

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -47,16 +47,17 @@ class DataToTempCSV:
         sensor_data = self.module_data["sensors"]
 
         for sensor in sensor_data:
-            sensor_type = self.module_id + "_" + sensor["type"]
+            sensor_name = self.module_id + "_" + sensor["type"]
             sensor_value = sensor["value"]
 
             if isinstance(sensor_value, dict):
+                # For nested sensor values
                 for sub_sensor in sensor_value.keys():
-                    sub_sensor_type = sensor_type + '_' + sub_sensor
+                    sub_sensor_name = sensor_name + '_' + sub_sensor
                     sub_sensor_value = sensor_value[sub_sensor]
-                    self.data_dict[sub_sensor_type] = sub_sensor_value
+                    self.data_dict[sub_sensor_name] = sub_sensor_value
             else:
-                self.data_dict[sensor_type] = sensor_value
+                self.data_dict[sensor_name] = sensor_value
 
     def parse_module_battery(self):
         """ Parses the module data if it is from the battery """

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -5,7 +5,7 @@ import csv
 
 
 class DataToTempCSV:
-    def __init__(self, msg, module_id="ALL"):
+    def __init__(self, msg, module_id="LOW_BAT"):
         self.msg = msg
         self.data_dict = {}
         self.module_id = module_id
@@ -51,7 +51,8 @@ class DataToTempCSV:
                 self.data_dict[sensor_type] = sensor_value
 
     def parse_module_battery(self):
-        self.data_dict[self.module_id + "_percentage"] = self.module_data["percentage"]
+        self.data_dict[self.module_id + "_percentage"] = \
+            self.module_data["percentage"]
 
     def parse_low_battery(self):
         self.data_dict["lowBattery"] = 1

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -8,8 +8,9 @@ class DataToTempCSV:
         self.msg = msg
         self.data_dict = {}
 
-        # if msg.topic[:18] == "v3/wireless-sensor" and msg.topic[-4:] == "data":
-        self.parse_wireless_module_data()
+        if msg.topic[:18] == "v3/wireless-sensor" and msg.topic[-4:] == "data":
+            self.parse_wireless_module_data()
+
         self.make_temp_csv()
 
 

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -1,0 +1,53 @@
+import json
+from datetime import datetime
+import os
+import csv
+
+class DataToTempCSV:
+    def __init__(self, msg):
+        self.msg = msg
+        self.data_dict = {}
+
+        # if msg.topic[:18] == "v3/wireless-sensor" and msg.topic[-4:] == "data":
+        self.parse_wireless_module_data()
+        self.make_temp_csv()
+
+
+    def parse_wireless_module_data(self):
+        module_data = self.msg.payload.decode("utf-8")    # Decode the data as utf-8
+        module_data = json.loads(module_data)           # Load from json to dict
+        sensor_data = module_data["sensors"]        # Retrieve sensor data
+        module_id = str("M" + self.msg.topic[19])        # Find module ID
+
+        for sensor in sensor_data:
+            sensor_type = module_id + "_" + sensor["type"]
+            sensor_value = sensor["value"]
+
+            if isinstance(sensor_value, dict):
+                pass
+            else:
+                self.data_dict[sensor_type] = sensor_value
+
+        # Add in the time and date that the data came in
+        self.data_dict[module_id + "_time"] = str(datetime.now().time())
+
+
+    def make_temp_csv(self):
+        # make sure that the temp file is
+        current_dir = os.path.dirname(__file__)
+        temp_filename = self.msg.topic.replace('/', '-')
+        temp_file_path = os.path.join(current_dir, str('.~temp_' + temp_filename + '.csv'))
+
+        fieldnames = []
+        for key in self.data_dict.keys():
+            fieldnames.append(key)
+
+        if not os.path.exists(temp_file_path):
+            # If the temp file does not exist write the headers for the CSV
+            with open(temp_file_path, mode='a') as temp_file:
+                csv_writer = csv.DictWriter(temp_file, fieldnames=fieldnames)
+                csv_writer.writeheader()
+
+        with open(temp_file_path, mode='a') as temp_file:
+            csv_writer = csv.DictWriter(temp_file, fieldnames=fieldnames)
+            csv_writer.writerow(self.data_dict)

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -13,28 +13,34 @@ class DataToTempCSV:
         self.data_dict = {}
         self.module_id = module_id
 
+        # Decode the data as utf-8 and load into python dict
+        self.module_data = self.msg.payload.decode("utf-8")
+        self.module_data = json.loads(self.module_data)
+
         if msg.topic[:18] == "v3/wireless-sensor" and msg.topic[-4:] == "data":
             self.parse_module_data()
 
         if msg.topic[:18] == "v3/wireless-sensor" and msg.topic[-7:] == "battery":
+            self.module_id = "M" + self.module_data["module-id"]
             self.parse_module_battery()
 
         if msg.topic == "v3/wireless-sensor/battery/low":
+            self.module_id = "M" + self.module_data["module-id"]
             self.parse_low_battery()
 
+        # Add in the time and date that the data came in
+        self.data_dict[self.module_id + "_time"] = str(datetime.now().time())
+
+        # Produce the temp CSV
         self.make_temp_csv()
+        print("recorded -->", self.data_dict)
 
     def parse_module_data(self):
-        # Decode the data as utf-8 and load into python dict
-        module_data = self.msg.payload.decode("utf-8")
-        module_data = json.loads(module_data)
         # Retrieve sensor data from python dict
-        sensor_data = module_data["sensors"]
-        # Find module ID
-        module_id = str("M" + self.msg.topic[19])
+        sensor_data = self.module_data["sensors"]
 
         for sensor in sensor_data:
-            sensor_type = module_id + "_" + sensor["type"]
+            sensor_type = self.module_id + "_" + sensor["type"]
             sensor_value = sensor["value"]
 
             if isinstance(sensor_value, dict):
@@ -46,28 +52,12 @@ class DataToTempCSV:
             else:
                 self.data_dict[sensor_type] = sensor_value
 
-        # Add in the time and date that the data came in
-        self.data_dict[module_id + "_time"] = str(datetime.now().time())
 
     def parse_module_battery(self):
-        # Decode the data as utf-8 and load into python dict
-        module_data = self.msg.payload.decode("utf-8")
-        module_data = json.loads(module_data)
-        # Retrieve module data from python dict
-        module_id = "M" + module_data["module-id"]
-
-        self.data_dict[module_id + "_percentage"] = module_data["percentage"]
-        self.data_dict[module_id + "_time"] = str(datetime.now().time())
+        self.data_dict[self.module_id + "_percentage"] = self.module_data["percentage"]
 
     def parse_low_battery(self):
-        # Decode the data as utf-8 and load into python dict
-        module_data = self.msg.payload.decode("utf-8")
-        module_data = json.loads(module_data)
-        # Retrieve module data from python dict
-        module_id = "M" + module_data["module-id"]
-
-        self.data_dict[module_id + "_lowBattery"] = True
-        self.data_dict[module_id + "_time"] = str(datetime.now().time())
+        self.data_dict[self.module_id + "_lowBattery"] = True
 
     def make_temp_csv(self):
         # make sure that the temp file is

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -16,7 +16,7 @@ class DataToTempCSV:
             self.parse_module_battery()
 
         if msg.topic == "v3/wireless-sensor/battery/low":
-            self.parse_low_batery()
+            self.parse_low_battery()
 
         self.make_temp_csv()
 
@@ -49,15 +49,21 @@ class DataToTempCSV:
         # Decode the data as utf-8 and load into python dict
         module_data = self.msg.payload.decode("utf-8")
         module_data = json.loads(module_data)
-        # Retrieve sensor data from python dict
-        module_id = module_data["module-id"]
-        module_percentage = module_data["percentage"]
+        # Retrieve module data from python dict
+        module_id = "M" + module_data["module-id"]
 
+        self.data_dict[module_id + "_percentage"] = module_data["percentage"]
+        self.data_dict[module_id + "_time"] = str(datetime.now().time())
 
-    def parse_low_batery(self):
+    def parse_low_battery(self):
         # Decode the data as utf-8 and load into python dict
         module_data = self.msg.payload.decode("utf-8")
         module_data = json.loads(module_data)
+        # Retrieve module data from python dict
+        module_id = "M" + module_data["module-id"]
+
+        self.data_dict[module_id + "_lowBattery"] = True
+        self.data_dict[module_id + "_time"] = str(datetime.now().time())
 
     def make_temp_csv(self):
         # make sure that the temp file is

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -12,29 +12,29 @@ def DataToTempCSV(msg, module_start_time, module_id):
     module_start_time:          Start time of the module (datetime obj)
     """
 
-    def parse_module_data(self):
+    def parse_module_data():
         """ Parses the module data if it is from the sensors """
 
         # Retrieve sensor data from python dict
-        sensor_data = self.module_data["sensors"]
+        sensor_data = module_data["sensors"]
 
         for sensor in sensor_data:
-            sensor_name = self.module_id + "_" + sensor["type"]
+            sensor_name = module_id + "_" + sensor["type"]
             sensor_value = sensor["value"]
 
             if isinstance(sensor_value, dict):
                 # For nested sensor values
                 for (sub_sensor, sub_sensor_value) in sensor_value.items():
                     sub_sensor_name = sensor_name + '_' + sub_sensor
-                    self.data_dict[sub_sensor_name] = sub_sensor_value
+                    data_dict[sub_sensor_name] = sub_sensor_value
             else:
-                self.data_dict[sensor_name] = sensor_value
+                data_dict[sensor_name] = sensor_value
 
     def parse_module_battery(self):
         """ Parses the module data if it is from the battery """
 
-        self.data_dict[self.module_id + "_percentage"] = \
-            self.module_data["percentage"]
+        data_dict[module_id + "_percentage"] = \
+            module_data["percentage"]
 
     def make_temp_csv(self):
         """ Makes a temporary CSV file that is hidden and is in the form of
@@ -42,7 +42,7 @@ def DataToTempCSV(msg, module_start_time, module_id):
 
         # Ensures that the temp file is in the same folder as the script
         current_dir = os.path.dirname(__file__)
-        temp_filename = '.~temp_' + self.module_id + '_' + self.type + '.csv'
+        temp_filename = '.~temp_' + module_id + '_' + type + '.csv'
         temp_file_path = os.path.join(current_dir, temp_filename)
 
         # If the temp file does not exist write the headers for the CSV
@@ -51,13 +51,13 @@ def DataToTempCSV(msg, module_start_time, module_id):
         with open(temp_file_path, mode='a') as temp_file:
             csv_writer = csv.DictWriter(
                 temp_file,
-                fieldnames=self.data_dict.keys())
+                fieldnames=data_dict.keys())
 
             if not new_file:
                 csv_writer.writeheader()
 
             # Append the data onto the temporary file
-            csv_writer.writerow(self.data_dict)
+            csv_writer.writerow(data_dict)
 
     data_dict = {}  # Data to be output to a temp CSV
 
@@ -86,4 +86,4 @@ def DataToTempCSV(msg, module_start_time, module_id):
     data_dict[time_dict_key] = time_delta
 
     # Add or create the temp CSV to store the data
-    self.make_temp_csv(module_data)
+    make_temp_csv(module_data)

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -4,42 +4,42 @@ import os
 import csv
 
 
-class DataToTempCSV:
-    """ Single use object to parse the MQTT data and convert it to a temporary
-    CSV file stored in the current derectory"""
+def DataToTempCSV(msg, module_start_time, module_id):
+    """ Function to parse the MQTT data and convert it to a temporary
+    CSV file stored in the current derectory
+    msg:                        Raw MQTT data
+    module_id:                  Module_id eg. M1, M2 or M3
+    module_start_time:          Start time of the module (datetime obj)
+    """
 
-    def __init__(self, msg, module_start_time, module_id):
-        self.msg = msg                  # Raw MQTT data
-        self.data_dict = {}             # Data to be output to a temp CSV
-        self.module_id = module_id      # Module_id eg. M1, M2 or M3
-        self.module_start_time = module_start_time  # Start time of the module
+    data_dict = {}             # Data to be output to a temp CSV
 
-        # Decode the data as utf-8 and load into python dict
-        self.module_data = self.msg.payload.decode("utf-8")
-        self.module_data = json.loads(self.module_data)
+    # Decode the data as utf-8 and load into python dict
+    module_data = msg.payload.decode("utf-8")
+    module_data = json.loads(module_data)
 
-        # Determine which type of data to parse
-        if msg.topic.endswith("data"):
-            self.type = "DATA"
-            self.parse_module_data()
+    # Determine which type of data to parse
+    if msg.topic.endswith("data"):
+        type = "DATA"
+        parse_module_data()
 
-        elif msg.topic.endswith("battery"):
-            self.type = "BATTERY"
-            self.parse_module_battery()
+    elif msg.topic.endswith("battery"):
+        type = "BATTERY"
+        parse_module_battery()
 
-        elif msg.topic == "/v3/wireless-module/battery/low":
-            self.type = "BATTERY_LOW"
-            # Nothing to parse
+    elif msg.topic == "/v3/wireless-module/battery/low":
+        type = "BATTERY_LOW"
+        # Nothing to parse
 
-        # Find the difference in seconds to when the recording was started and
-        # when the data was recieved.
-        self.time_delta = datetime.now() - self.module_start_time
-        self.time_delta = self.time_delta.total_seconds()
-        time_dict_key = f"{self.module_id}_{self.type}_TIME"
-        self.data_dict[time_dict_key] = self.time_delta
+    # Find the difference in seconds to when the recording was started and
+    # when the data was recieved.
+    time_delta = datetime.now() - module_start_time
+    time_delta = time_delta.total_seconds()
+    time_dict_key = f"{module_id}_{type}_TIME"
+    data_dict[time_dict_key] = time_delta
 
-        # Add or create the temp CSV to store the data
-        self.make_temp_csv()
+    # Add or create the temp CSV to store the data
+    self.make_temp_csv()
 
     def parse_module_data(self):
         """ Parses the module data if it is from the sensors """

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -18,15 +18,15 @@ class DataToTempCSV:
         self.module_data = json.loads(self.module_data)
 
         # Determine which data to parse
-        if msg.topic[:18] == "v3/wireless-sensor" and msg.topic[-4:] == "data":
+        if msg.topic.endswith("data"):
             self.type = "DATA"
             self.parse_module_data()
 
-        if msg.topic[:18] == "v3/wireless-sensor" and msg.topic[-7:] == "battery":
+        elif msg.topic.endswith("battery"):
             self.type = "BATTERY"
             self.parse_module_battery()
 
-        if msg.topic == "v3/wireless-sensor/battery/low":
+        elif msg.topic == "v3/wireless-sensor/battery/low":
             self.type = "BATTERY_LOW"
             self.parse_low_battery()
 

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -5,9 +5,13 @@ import csv
 
 
 class DataToTempCSV:
-    def __init__(self, msg):
+    def __init__(self, msg, module_id):
+        # TODO: FIX THE TOPICS TO SPEC
+        # TODO: ADD THE CORRECT '/'
+
         self.msg = msg
         self.data_dict = {}
+        self.module_id = module_id
 
         if msg.topic[:18] == "v3/wireless-sensor" and msg.topic[-4:] == "data":
             self.parse_module_data()

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -31,7 +31,8 @@ class DataToTempCSV:
             self.parse_low_battery()
 
         # Add in the time and date that the data came in
-        self.data_dict[self.module_id + "_" + self.type + "_time"] = str(datetime.now().time())
+        current_time = str(datetime.now().time())
+        self.data_dict[self.module_id+"_"+self.type+"_time"] = current_time
 
         # Add or create the temp CSV to store the data
         self.make_temp_csv()
@@ -58,23 +59,24 @@ class DataToTempCSV:
 
     def parse_low_battery(self):
         self.data_dict["lowBattery"] = 1
-        print("recorded -->", self.data_dict)
 
     def make_temp_csv(self):
         # Ensures that the temp file is in the same folder as the script
         current_dir = os.path.dirname(__file__)
-        temp_filename = str('.~temp_' + self.module_id + '_' + self.type + '.csv')
+        temp_filename = str('.~temp_' + self.module_id+'_'+self.type + '.csv')
         temp_file_path = os.path.join(current_dir, temp_filename)
 
         column_names = []
         for key in self.data_dict.keys():
             column_names.append(key)
 
+        # If the temp file does not exist write the headers for the CSV
+        new_file = os.path.exists(temp_file_path)
+
         with open(temp_file_path, mode='a') as temp_file:
             csv_writer = csv.DictWriter(temp_file, fieldnames=column_names)
 
-            # If the temp file does not exist write the headers for the CSV
-            if not os.path.exists(temp_file_path):
+            if not new_file:
                 csv_writer.writeheader()
 
             # Append the data onto the temporary file

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -30,13 +30,13 @@ def DataToTempCSV(msg, module_start_time, module_id):
             else:
                 data_dict[sensor_name] = sensor_value
 
-    def parse_module_battery(self):
+    def parse_module_battery():
         """ Parses the module data if it is from the battery """
 
         data_dict[module_id + "_percentage"] = \
             module_data["percentage"]
 
-    def make_temp_csv(self):
+    def make_temp_csv():
         """ Makes a temporary CSV file that is hidden and is in the form of
         .~temp_<filename>.csv in the current directory"""
 
@@ -46,14 +46,14 @@ def DataToTempCSV(msg, module_start_time, module_id):
         temp_file_path = os.path.join(current_dir, temp_filename)
 
         # If the temp file does not exist write the headers for the CSV
-        new_file = os.path.exists(temp_file_path)
+        temp_exists = os.path.exists(temp_file_path)
 
         with open(temp_file_path, mode='a') as temp_file:
             csv_writer = csv.DictWriter(
                 temp_file,
                 fieldnames=data_dict.keys())
 
-            if not new_file:
+            if not temp_exists:
                 csv_writer.writeheader()
 
             # Append the data onto the temporary file
@@ -86,4 +86,4 @@ def DataToTempCSV(msg, module_start_time, module_id):
     data_dict[time_dict_key] = time_delta
 
     # Add or create the temp CSV to store the data
-    make_temp_csv(module_data)
+    make_temp_csv()

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -74,16 +74,13 @@ class DataToTempCSV:
         temp_filename = str('.~temp_' + self.module_id+'_'+self.type + '.csv')
         temp_file_path = os.path.join(current_dir, temp_filename)
 
-        # Find the names for the CSV columns
-        column_names = []
-        for key in self.data_dict.keys():
-            column_names.append(key)
-
         # If the temp file does not exist write the headers for the CSV
         new_file = os.path.exists(temp_file_path)
 
         with open(temp_file_path, mode='a') as temp_file:
-            csv_writer = csv.DictWriter(temp_file, fieldnames=column_names)
+            csv_writer = csv.DictWriter(
+                temp_file,
+                fieldnames=self.data_dict.keys())
 
             if not new_file:
                 csv_writer.writeheader()

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -25,10 +25,15 @@ class DataToTempCSV:
             sensor_value = sensor["value"]
 
             if isinstance(sensor_value, dict):
-                pass
+                for sub_sensor in sensor_value.keys():
+                    sub_sensor_type = sensor_type + '_' + sub_sensor
+                    sub_sensor_value = sensor_value[sub_sensor]
+                    self.data_dict[sub_sensor_type] = sub_sensor_value
+
             else:
                 self.data_dict[sensor_type] = sensor_value
 
+        print(self.data_dict)
         # Add in the time and date that the data came in
         self.data_dict[module_id + "_time"] = str(datetime.now().time())
 

--- a/Raspi/Test/DataToTempCSV.py
+++ b/Raspi/Test/DataToTempCSV.py
@@ -71,7 +71,7 @@ class DataToTempCSV:
 
         # Ensures that the temp file is in the same folder as the script
         current_dir = os.path.dirname(__file__)
-        temp_filename = str('.~temp_' + self.module_id+'_'+self.type + '.csv')
+        temp_filename = '.~temp_' + self.module_id + '_' + self.type + '.csv'
         temp_file_path = os.path.join(current_dir, temp_filename)
 
         # If the temp file does not exist write the headers for the CSV

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -8,7 +8,7 @@ import json
 
 def on_connect(client, userdata, flags, rc):
     if rc == 0:
-        print("Connected Sucessfully! Result code: " + str(rc))
+        print("Connected Successfully! Result code: " + str(rc))
 
     else:
         print("Something went wrong! Result code: " + str(rc))
@@ -85,9 +85,6 @@ def save_temp_csv(module_id):
     merge_temps(output_filename, temp_filepaths)
     # remove_temps(temp_filepaths)
 
-    # print(filename)
-    # print(temp_filepaths)
-
 
 def find_temp_csvs(module_id=""):
     """Searches throught the current directory and finds all the temp files and
@@ -95,12 +92,12 @@ def find_temp_csvs(module_id=""):
     current_dir = os.path.dirname(__file__)
 
     if current_dir == '':
-        filenames = os.listdir()
+        filepaths = os.listdir()
     else:
-        filenames = os.listdir(current_dir)
+        filepaths = os.listdir(current_dir)
 
     temp_filepaths = []
-    for filename in filenames:
+    for filename in filepaths:
         # Find the temp filepaths and store in the array
         if filename.startswith(".~temp_" + module_id) and filename.endswith(".csv"):
             if current_dir == '':
@@ -129,21 +126,22 @@ def merge_temps(output_filename, temp_filepaths):
 
 
 if __name__ == "__main__":
-    is_recording = {
-        "M1": False,
-        "M2": False,
-        "M3": False,
-        "M1_filename": None,
-        "M2_filename": None,
-        "M2_filename": None,
-    }
-
-    broker_address = 'localhost'
-    client = mqtt.Client()
-
-    client.on_connect = on_connect
-    client.on_message = on_message
-
-    client.connect(broker_address)
-
-    client.loop_forever()
+    save_temp_csv("M1")
+    # is_recording = {
+    #     "M1": False,
+    #     "M2": False,
+    #     "M3": False,
+    #     "M1_filename": None,
+    #     "M2_filename": None,
+    #     "M2_filename": None,
+    # }
+    #
+    # broker_address = 'localhost'
+    # client = mqtt.Client()
+    #
+    # client.on_connect = on_connect
+    # client.on_message = on_message
+    #
+    # client.connect(broker_address)
+    #
+    # client.loop_forever()

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -31,6 +31,7 @@ def on_connect(client, userdata, flags, rc):
 
 def subscribe_to_all(client):
     # TODO: FIX THE TOPICS TO SPEC
+    # TODO: ADD THE CORRECT '/'
 
     # Subscribe to all of the data topics
     client.subscribe("v3/wireless-sensor/1/data")
@@ -43,13 +44,30 @@ def subscribe_to_all(client):
     client.subscribe("v3/wireless-sensor/2/battery")
     client.subscribe("v3/wireless-sensor/3/battery")
 
+    # Subscribe to all of the start topics
+    client.subscribe("v3/wireless-module/1/start")
+    client.subscribe("v3/wireless-module/2/start")
+    client.subscribe("v3/wireless-module/3/start")
+
+    # Subscribe to all of the stop topics
+    client.subscribe("v3/wireless-module/1/stop")
+    client.subscribe("v3/wireless-module/2/stop")
+    client.subscribe("v3/wireless-module/3/stop")
+
 
 def on_message(client, userdata, msg):
     # TODO: FIX THE TOPICS TO SPEC
-    # IMPLEMENT A FUNCTION FOR THIS
-    # /v3/wireless-module/<id>/start
-    # /v3/wireless-module/<id>/stop
-    DataToTempCSV(msg)
+    # TODO: ADD THE CORRECT '/'
+    module_id = str("M" + msg.topic[19])
+    if msg.topic[:18] == "v3/wireless-module" and msg.topic[-5:] == "start":
+        is_recording[module_id] = True
+
+    elif msg.topic[:18] == "v3/wireless-module" and msg.topic[-4:] == "stop":
+        is_recording[module_id] = False
+
+    else:
+        if is_recording[module_id] is True:
+            DataToTempCSV(msg, module_id)
 
 
 def merge_temps(output_filename):
@@ -84,6 +102,12 @@ def merge_temps_pandas(output_filename, temp_filenames):
 
 
 if __name__ == "__main__":
+    is_recording = {
+        "M1": False,
+        "M2": False,
+        "M3": False,
+    }
+
     broker_address = 'localhost'
     client = mqtt.Client()
 

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -3,7 +3,6 @@ import json
 import argparse
 import paho.mqtt.client as mqtt
 import os
-import pandas as pd
 
 """
 # USE 3 TEMP CSV and then merge at the end
@@ -95,24 +94,12 @@ def temp_csv(data_name, data_dict):
         # csv_writer.writerow(['Erica Meyers', 'IT', 'March'])
 
 
-
-
 if __name__ == "__main__":
 
     temp_csv("sensor1", {'data_dict': 3, 'yoyoy': 'helloworld'})
 
     # # GO WITH 3 CSVs
     # # TODO: REMOVE THIS FOR CLI VERSION
-    # dir = os.path.dirname(__file__)
-    # filename = os.path.join(dir, 'mqtt_wireless_log.csv')
-    # print(filename)
-    #
-    # df = pd.read_csv(filename)
-    # print(df.iloc[-1]['temperature'])
-    # df.iloc[-1]['temperature'] = 1
-    # print(df.iloc[-1]['temperature'])
-    #
-    # # print(df.loc(0, 'temperature'))
     #
     # broker_address = 'localhost'
     # client = mqtt.Client()

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -17,20 +17,9 @@ import paho.mqtt.client as mqtt
 def on_connect(client, userdata, flags, rc):
     if rc == 0:
         print("Connected Sucessfully! Result code: " + str(rc))
+
     else:
         print("Something went wrong! Result code: " + str(rc))
-
-
-def on_message(client, userdata, msg):
-    print(msg.topic+" "+str(msg.payload.decode("utf-8")))
-
-
-if __name__ == "__main__":
-    broker_address = 'localhost'
-    client = mqtt.Client()
-
-    client.on_connect = on_connect
-    client.on_message = on_message
 
     # Subscribe to all of the data topics
     client.subscribe("/v3/wireless-module/1/data")
@@ -43,6 +32,19 @@ if __name__ == "__main__":
     client.subscribe("/v3/wireless-module/2/battery")
     client.subscribe("/v3/wireless-module/3/battery")
 
+
+def on_message(client, userdata, msg):
+    print(msg.topic)
+
+
+if __name__ == "__main__":
+    broker_address = 'localhost'
+    client = mqtt.Client()
+
+    client.on_connect = on_connect
+    client.on_message = on_message
+
+
     client.connect(broker_address)
-    client.loop_start()
-    client.loop_stop()
+
+    client.loop_forever()

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -62,6 +62,7 @@ def merge_temps(output_filename):
     merges them it finds a """
     current_dir = os.path.dirname(__file__)
     filenames = os.listdir(current_dir)
+    output_filename = current_dir + '/' + output_filename
 
     temp_filenames = []
 
@@ -77,7 +78,6 @@ def merge_temps_pandas(output_filename, temp_filenames):
     df_array = []
     df_columns = []
     dataframe = pd.DataFrame()
-    print(dataframe)
     for temp_filename in temp_filenames:
 
         temp = pd.read_csv(temp_filename)
@@ -85,15 +85,14 @@ def merge_temps_pandas(output_filename, temp_filenames):
             print('-->',str(column))
             dataframe[str(column)] = temp[column]
 
-
-    print(dataframe)
-    dataframe.to_csv("aaaa.csv")
+    dataframe.to_csv(output_filename)
 
 
 def parse_wireless_module_data(msg):
     module_data = msg.payload.decode("utf-8")
     module_data = json.loads(module_data)
     sensor_data = module_data["sensors"]
+
     # data_dict will be used to store the data before being entered into the csv
     data_dict = {}
 
@@ -120,7 +119,6 @@ def temp_csv(data_name, data_dict):
     fieldnames = []
     for key in data_dict.keys():
         fieldnames.append(key)
-    # print(temp_file_path)
 
     if not os.path.exists(temp_file_path):
         # If the temp file does not exist write the headers for the CSV
@@ -131,26 +129,9 @@ def temp_csv(data_name, data_dict):
     with open(temp_file_path, mode='a') as temp_file:
         csv_writer = csv.DictWriter(temp_file, fieldnames=fieldnames)
         csv_writer.writerow(data_dict)
-        # csv_writer.writerow(['Erica Meyers', 'IT', 'March'])
 
 
 if __name__ == "__main__":
-    merge_temps('merged_output')
-    # mydictionary = {'names': ['Somu', 'Kiku', 'Amol', 'Lini'],
-	# 'physics': [68, 74, 77, 78],
-	# 'chemistry': [84, 56, 73, 69],
-	# 'algebra': [78, 88, 82, 87]}
-    #
-    # #create dataframe
-    # df_marks = pd.DataFrame(mydictionary)
-    # print('Original DataFrame\n--------------')
-    # print(df_marks)
-    #
-    # #add column
-    # df_marks['geometry'] = [81, 92, 67, 76]
-    # print('\n\nDataFrame after adding "geometry" column\n--------------')
-    # print(df_marks)
-
     # broker_address = 'localhost'
     # client = mqtt.Client()
     #
@@ -159,4 +140,4 @@ if __name__ == "__main__":
     #
     # client.connect(broker_address)
     #
-    # client.loop_forever()\\
+    # client.loop_forever()

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -42,7 +42,7 @@ def on_message(client, userdata, msg):
 
     # Check to see if the topic ends in "data", selecting only the msg's that
     # have wireless_module_data
-    if msg.topic[-4:] == "data":
+    if msg.topic[:19] == "/v3/wireless-module" and msg.topic[-4:] == "data":
         parse_wireless_module_data(msg.payload)
 
 

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -2,6 +2,8 @@ import csv
 import json
 import argparse
 import paho.mqtt.client as mqtt
+import os
+import pandas as pd
 
 """
 1. Subscribe to the chanels
@@ -54,11 +56,37 @@ def parse_wireless_module_data(msg):
         sensor_type = sensor["type"]
         sensor_value = sensor["value"]
 
+
+
+        # with open(filename, mode='a') as csv_file:
+        #
+        #     fieldnames = ['co2', 'temperature', 'humidity', 'accelerometer', 'gyroscope']
+        #     writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        #
+        #     writer.writeheader()
+        #     writer.writerow({sensor_type: sensor_value})
+        #     # writer.writerow({'dept': 'IT', 'birth_month': 'March', 'emp_name': 'Erica Meyers'})
+
+
+
     # print(sensor_data)
     # print(module_data)
 
 
 if __name__ == "__main__":
+    # GO WITH 3 CSVs
+    # TODO: REMOVE THIS FOR CLI VERSION
+    dir = os.path.dirname(__file__)
+    filename = os.path.join(dir, 'mqtt_wireless_log.csv')
+    print(filename)
+
+    df = pd.read_csv(filename)
+    print(df.iloc[-1]['temperature'])
+    df.iloc[-1]['temperature'] = 1
+    print(df.iloc[-1]['temperature'])
+
+    # print(df.loc(0, 'temperature'))
+
     broker_address = 'localhost'
     client = mqtt.Client()
 

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -47,8 +47,70 @@ def on_message(client, userdata, msg):
     # Check to see if the topic ends in "data", selecting only the msg's that
     # have wireless_module_data
     if msg.topic[:19] == "/v3/wireless-module" and msg.topic[-4:] == "data":
-        data = parse_wireless_module_data(msg)
-        temp_csv('sensor1', data)
+        sensor_id = str(msg.topic[20])
+        data_dict = parse_wireless_module_data(msg)
+        temp_csv('S'+sensor_id, data_dict)
+
+
+def merge_temps(output_filename):
+    """Searches throught the current directory and finds all the temp files and merges them
+    it finds a """
+    current_dir = os.path.dirname(__file__)
+    filenames = os.listdir(current_dir)
+
+    temp_filenames = []
+
+    for filename in filenames:
+        # Find the temp files and store in the array
+        if filename[-4:]==".csv" and filename[:6]==".~temp":
+            temp_filenames.append(current_dir + '/' + filename)
+
+    merge_temps_continued(output_filename, temp_filenames)
+
+def merge_temps_continued(output_filename, temp_filenames):
+    end_of_csv = False
+    current_line_num = 0
+    while not end_of_csv:
+
+        merged_csv_fieldnames = []
+        current_merged_dict = {}
+        current_dir = os.path.dirname(__file__)
+        merged_csv_path = os.path.join(current_dir, str(output_filename + '.csv'))
+
+        for filename in temp_filenames:
+            csv_file = open(filename, mode='r')
+            csv_reader = csv.reader(csv_file, delimiter=',')
+
+            line_count = 0
+            for row in csv_reader:
+                if line_count == 0:
+
+                    print(row)
+                else:
+                    print('0')
+
+                line_count += 1
+                # for_row_num
+                #
+                # current_row_num
+                # # First line
+                # if line_num == 0:
+                #
+                #
+                #     print('HEADERS -->', )
+                # else:
+                #     for i in range(line_num):
+                #         if i == line_num:
+                #             print()
+
+        end_of_csv = True
+
+
+        #write to merged csv
+        with open(merged_csv_path, mode='a') as csv_file:
+            csv_writer = csv.DictWriter(csv_file, fieldnames=merged_csv_fieldnames)
+            csv_writer.writeheader()
+            csv_writer.writerow(current_merged_dict)
 
 
 def parse_wireless_module_data(msg):
@@ -62,7 +124,8 @@ def parse_wireless_module_data(msg):
         sensor_type = sensor["type"]
         sensor_value = sensor["value"]
         if isinstance(sensor_value, dict):
-            print(sensor_value)
+            # print(sensor_value)
+            pass
         else:
             data_dict[sensor_type] = sensor_value
 
@@ -77,11 +140,10 @@ def temp_csv(data_name, data_dict):
     current_dir = os.path.dirname(__file__)
     temp_file_path = os.path.join(current_dir, str('.~temp_' + data_name + '.csv'))
 
-    print(type(data_dict.keys()))
     fieldnames = []
     for key in data_dict.keys():
         fieldnames.append(key)
-    print(temp_file_path)
+    # print(temp_file_path)
 
     if not os.path.exists(temp_file_path):
         # If the temp file does not exist write the headers for the CSV
@@ -96,15 +158,13 @@ def temp_csv(data_name, data_dict):
 
 
 if __name__ == "__main__":
-    # GO WITH 3 CSVs
-    # TODO: REMOVE THIS FOR CLI VERSION
-
-    broker_address = 'localhost'
-    client = mqtt.Client()
-
-    client.on_connect = on_connect
-    client.on_message = on_message
-
-    client.connect(broker_address)
-
-    client.loop_forever()
+    merge_temps('merged_output')
+    # broker_address = 'localhost'
+    # client = mqtt.Client()
+    #
+    # client.on_connect = on_connect
+    # client.on_message = on_message
+    #
+    # client.connect(broker_address)
+    #
+    # client.loop_forever()

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -1,9 +1,6 @@
-import csv
-import json
 import argparse
 import paho.mqtt.client as mqtt
 import os
-from datetime import datetime
 import pandas as pd
 from DataToTempCSV import DataToTempCSV
 
@@ -49,21 +46,11 @@ def subscribe_to_all(client):
 
 def on_message(client, userdata, msg):
     # TODO: FIX THE TOPICS TO SPEC
-
-    # Capture the data and decode the JSON
-
     # IMPLEMENT A FUNCTION FOR THIS
     # /v3/wireless-module/<id>/start
     # /v3/wireless-module/<id>/stop
-
-    # Check to see if the topic ends in "data", selecting only the msg's that
-    # have wireless_module_data
-    # if msg.topic[:18] == "v3/wireless-sensor" and msg.topic[-4:] == "data":
-    #     data_dict = parse_wireless_module_data(msg)
-    #     temp_csv(msg, data_dict)
-    #     print(msg.payload.decode("utf-8"))
-
     DataToTempCSV(msg)
+
 
 def merge_temps(output_filename):
     """Searches throught the current directory and finds all the temp files and
@@ -94,51 +81,6 @@ def merge_temps_pandas(output_filename, temp_filenames):
             dataframe[str(column)] = temp[column]
 
     dataframe.to_csv(output_filename)
-
-
-def parse_wireless_module_data(msg):
-    module_data = msg.payload.decode("utf-8")   # Decode the data as utf-8
-    module_data = json.loads(module_data)       # Load from json to dict
-    sensor_data = module_data["sensors"]        # Retrieve sensor data
-    module_id = str("M" + msg.topic[19])        # Find module ID
-
-    # Used to store the data before being entered into the csv
-    data_dict = {}
-
-    for sensor in sensor_data:
-        sensor_type = module_id + "_" + sensor["type"]
-        sensor_value = sensor["value"]
-
-        if isinstance(sensor_value, dict):
-            pass
-        else:
-            data_dict[sensor_type] = sensor_value
-
-    # Add in the time and date that the data came in
-    data_dict[module_id + "_time"] = str(datetime.now().time())
-    return data_dict
-
-
-def temp_csv(msg, data_dict):
-    # make sure that the temp file is
-    current_dir = os.path.dirname(__file__)
-    temp_filename = msg.topic.replace('/', '-')
-    temp_file_path = os.path.join(current_dir, str('.~temp_' + temp_filename + '.csv'))
-
-    fieldnames = []
-    for key in data_dict.keys():
-        fieldnames.append(key)
-
-    # print(temp_file_path)
-    if not os.path.exists(temp_file_path):
-        # If the temp file does not exist write the headers for the CSV
-        with open(temp_file_path, mode='a') as temp_file:
-            csv_writer = csv.DictWriter(temp_file, fieldnames=fieldnames)
-            csv_writer.writeheader()
-
-    with open(temp_file_path, mode='a') as temp_file:
-        csv_writer = csv.DictWriter(temp_file, fieldnames=fieldnames)
-        csv_writer.writerow(data_dict)
 
 
 if __name__ == "__main__":

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -1,0 +1,4 @@
+import csv
+import json
+import argparse
+import paho.mqtt.client as mqtt

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -2,3 +2,13 @@ import csv
 import json
 import argparse
 import paho.mqtt.client as mqtt
+
+"""
+1. Subscribe to the chanels
+2. Capture and decode the JSON
+3. Convert the json to csv
+4. append the data to the csv file
+
+# NOTE: The battery will be implemented later. Just do the key data first.
+
+"""

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -60,7 +60,7 @@ def on_message(client, userdata, msg):
     # TODO: FIX THE TOPICS TO SPEC
     # TODO: ADD THE CORRECT '/'
     module_id = str("M" + msg.topic[19])
-    if msg.topic[:18] == "v3/wireless-module" and msg.topic[-5:] == "start":
+    if msg.topic.endswith("start"):
         # Decode the data as utf-8 and load into python dict
         start_data = msg.payload.decode("utf-8")
         start_data = json.loads(start_data)
@@ -74,7 +74,7 @@ def on_message(client, userdata, msg):
         # mosquitto_pub -h localhost -t v3/wireless-module/1/stop -m ''
         # mosquitto_pub -h localhost -t v3/wireless-sensor/battery/low -m '{"module-id": 1}'
 
-    elif msg.topic[:18] == "v3/wireless-module" and msg.topic[-4:] == "stop":
+    elif msg.topic.endswith("stop"):
         # Update is_recording to stop the recording of the wireless module
         is_recording[module_id] = False
         print(module_id, "STOPPED")
@@ -86,7 +86,7 @@ def on_message(client, userdata, msg):
     else:
         if msg.topic == "v3/wireless-sensor/battery/low":
             DataToTempCSV(msg)
-        elif (is_recording[module_id] is True) or True:
+        elif is_recording[module_id] is True:
             DataToTempCSV(msg, module_id)
 
 

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -125,9 +125,13 @@ def merge_temps(output_filename, temp_filepaths):
 
 
 if __name__ == "__main__":
+    # Clear the old temporary files in the folder, just in case the script
+    # exited early and they were not cleared properly
     remove_files(find_temp_csvs())
 
-    # M1, M1_filename
+    # Global dicts to store whether the module is currently
+    # recording data (boolean) and the output filename for the module (string).
+    # Dict structure is {<module_id> : <data>}
     is_recording = {}
     output_filename = {}
 

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -34,7 +34,21 @@ def on_connect(client, userdata, flags, rc):
 
 
 def on_message(client, userdata, msg):
-    print(msg.topic)
+    # Capture the data and decode the JSON
+
+    # IMPLEMENT A FUNCTION FOR THIS
+    # /v3/wireless-module/<id>/start
+    # /v3/wireless-module/<id>/stop
+
+    # Check to see if the topic ends in "data", selecting only the msg's that
+    # have wireless_module_data
+    if msg.topic[-4:] == "data":
+        parse_wireless_module_data(msg.payload)
+
+
+def parse_wireless_module_data(msg_payload):
+    module_data = msg_payload.decode("utf-8")
+    module_data = json.loads(module_data)
 
 
 if __name__ == "__main__":

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -5,20 +5,6 @@ import pandas as pd
 from DataToTempCSV import DataToTempCSV
 import json
 
-"""
-FIX THE "wireless-sensor" --> "wireless-module"
-
-# USE 3 TEMP CSV and then merge at the end
-
-1. Subscribe to the chanels
-2. Capture and decode the JSON
-3. Convert the json to csv
-4. append the data to the csv file
-
-# NOTE: The battery will be implemented later. Just do the key data first.
-
-"""
-
 
 def on_connect(client, userdata, flags, rc):
     if rc == 0:
@@ -94,12 +80,13 @@ def save_temp_csv(module_id):
     print(module_id)
     output_filename = is_recording[module_id + "_filename"]
     print(output_filename)
-    temp_filenames = find_temp_csvs(module_id)
-    print(temp_filenames)
-    merge_temps(output_filename, temp_filenames)
-    remove_temps(temp_filenames)
+    temp_filepaths = find_temp_csvs(module_id)
+    print(temp_filepaths)
+    merge_temps(output_filename, temp_filepaths)
+    # remove_temps(temp_filepaths)
+
     # print(filename)
-    # print(temp_filenames)
+    # print(temp_filepaths)
 
 
 def find_temp_csvs(module_id=""):
@@ -112,27 +99,27 @@ def find_temp_csvs(module_id=""):
     else:
         filenames = os.listdir(current_dir)
 
-    temp_filenames = []
+    temp_filepaths = []
     for filename in filenames:
         # Find the temp filepaths and store in the array
         if filename.startswith(".~temp_" + module_id) and filename.endswith(".csv"):
             if current_dir == '':
-                temp_filenames.append(filename)
+                temp_filepaths.append(filename)
             else:
-                temp_filenames.append(current_dir + '/' + filename)
+                temp_filepaths.append(current_dir + '/' + filename)
 
-    return temp_filenames
+    return temp_filepaths
 
 
-def remove_temps(filenames):
-    for file in filenames:
+def remove_temps(filepaths):
+    """ Removes the files in the list of filepaths """
+    for file in filepaths:
         os.remove(file)
 
 
-def merge_temps(output_filename, temp_filenames):
-    return
+def merge_temps(output_filename, temp_filepaths):
     dataframe = pd.DataFrame()
-    for temp_filename in temp_filenames:
+    for temp_filename in temp_filepaths:
 
         temp = pd.read_csv(temp_filename)
         for column in temp.columns:

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -1,4 +1,3 @@
-import argparse
 import paho.mqtt.client as mqtt
 import os
 import pandas as pd
@@ -61,24 +60,36 @@ def on_message(client, userdata, msg):
 
 
 def save_temp_csv(module_id):
+    """ Saves the temp csvs into real csvs where the battery data and the
+    module data is combined into a single CSV"""
+
+    # Find the temp files in the current folder for the current module
     temp_filepaths = find_temp_csvs(module_id)
+
+    # Merge the battery and sensor data into a single CSV
     merge_temps(output_filename[module_id], temp_filepaths)
+
+    # Remove the temp files for the specific module that where generated
     remove_files(temp_filepaths)
 
 
 def find_temp_csvs(module_id=""):
-    """Searches throught the current directory and finds all the temp files and
-    merges them it finds a """
+    """ Searches throught the current directory and finds all the temp files
+    for a specific module_id and returns the filepaths in a list. If no
+    module_id is given then all temporary files will be found and returned
+    in a list."""
+
     current_dir = os.path.dirname(__file__)
 
+    # Depends on where the python script is called from
     if current_dir == '':
         filepaths = os.listdir()
     else:
         filepaths = os.listdir(current_dir)
 
+    # Find temp filepaths and store in the temp_filepaths list
     temp_filepaths = []
     for filename in filepaths:
-        # Find the temp filepaths and store in the array
         if filename.startswith(".~temp_" + module_id) and filename.endswith(".csv"):
             if current_dir == '':
                 temp_filepaths.append(filename)
@@ -89,7 +100,9 @@ def find_temp_csvs(module_id=""):
 
 
 def remove_files(filepaths):
-    """ Removes the files in the list of filepaths """
+    """ Removes the files in a list of filepaths
+    filepaths: Example list of filepaths is [filepath1, filepath2, filepath3]
+    """
     for file in filepaths:
         os.remove(file)
 
@@ -108,15 +121,8 @@ def merge_temps(output_filename, temp_filepaths):
 if __name__ == "__main__":
     remove_files(find_temp_csvs())
 
-    is_recording = {
-        # "M1": False,
-        # "M2": False,
-        # "M3": False,
-        # "M1_filename": None,
-        # "M2_filename": None,
-        # "M3_filename": None,
-    }
-
+    # M1, M1_filename
+    is_recording = {}
     output_filename = {}
 
     broker_address = 'localhost'

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -6,6 +6,8 @@ import os
 import pandas as pd
 
 """
+# USE 3 TEMP CSV and then merge at the end
+
 1. Subscribe to the chanels
 2. Capture and decode the JSON
 3. Convert the json to csv
@@ -56,8 +58,6 @@ def parse_wireless_module_data(msg):
         sensor_type = sensor["type"]
         sensor_value = sensor["value"]
 
-
-
         # with open(filename, mode='a') as csv_file:
         #
         #     fieldnames = ['co2', 'temperature', 'humidity', 'accelerometer', 'gyroscope']
@@ -68,31 +68,58 @@ def parse_wireless_module_data(msg):
         #     # writer.writerow({'dept': 'IT', 'birth_month': 'March', 'emp_name': 'Erica Meyers'})
 
 
-
     # print(sensor_data)
     # print(module_data)
 
 
+def temp_csv(data_name, data_dict):
+    # make sure that the temp file is
+    current_dir = os.path.dirname(__file__)
+    temp_file_path = os.path.join(current_dir, str('.~temp_' + data_name + '.csv'))
+
+    print(type(data_dict.keys()))
+    fieldnames = []
+    for key in data_dict.keys():
+        fieldnames.append(key)
+    print(temp_file_path)
+
+    if not os.path.exists(temp_file_path):
+        # If the temp file does not exist write the headers for the CSV
+        with open(temp_file_path, mode='a') as temp_file:
+            csv_writer = csv.DictWriter(temp_file, fieldnames=fieldnames)
+            csv_writer.writeheader()
+
+    with open(temp_file_path, mode='a') as temp_file:
+        csv_writer = csv.DictWriter(temp_file, fieldnames=fieldnames)
+        csv_writer.writerow(data_dict)
+        # csv_writer.writerow(['Erica Meyers', 'IT', 'March'])
+
+
+
+
 if __name__ == "__main__":
-    # GO WITH 3 CSVs
-    # TODO: REMOVE THIS FOR CLI VERSION
-    dir = os.path.dirname(__file__)
-    filename = os.path.join(dir, 'mqtt_wireless_log.csv')
-    print(filename)
 
-    df = pd.read_csv(filename)
-    print(df.iloc[-1]['temperature'])
-    df.iloc[-1]['temperature'] = 1
-    print(df.iloc[-1]['temperature'])
+    temp_csv("sensor1", {'data_dict': 3, 'yoyoy': 'helloworld'})
 
-    # print(df.loc(0, 'temperature'))
-
-    broker_address = 'localhost'
-    client = mqtt.Client()
-
-    client.on_connect = on_connect
-    client.on_message = on_message
-
-    client.connect(broker_address)
-
-    client.loop_forever()
+    # # GO WITH 3 CSVs
+    # # TODO: REMOVE THIS FOR CLI VERSION
+    # dir = os.path.dirname(__file__)
+    # filename = os.path.join(dir, 'mqtt_wireless_log.csv')
+    # print(filename)
+    #
+    # df = pd.read_csv(filename)
+    # print(df.iloc[-1]['temperature'])
+    # df.iloc[-1]['temperature'] = 1
+    # print(df.iloc[-1]['temperature'])
+    #
+    # # print(df.loc(0, 'temperature'))
+    #
+    # broker_address = 'localhost'
+    # client = mqtt.Client()
+    #
+    # client.on_connect = on_connect
+    # client.on_message = on_message
+    #
+    # client.connect(broker_address)
+    #
+    # client.loop_forever()

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -26,14 +26,23 @@ def on_message(client, userdata, msg):
 
 
 if __name__ == "__main__":
-    # Subscribe to all of data topics
     broker_address = 'localhost'
     client = mqtt.Client()
 
     client.on_connect = on_connect
     client.on_message = on_message
 
+    # Subscribe to all of the data topics
+    client.subscribe("/v3/wireless-module/1/data")
+    client.subscribe("/v3/wireless-module/2/data")
+    client.subscribe("/v3/wireless-module/3/data")
+
+    # Subscribe to all of the battery topics
+    client.subscribe("/v3/wireless-module/battery/low")
+    client.subscribe("/v3/wireless-module/1/battery")
+    client.subscribe("/v3/wireless-module/2/battery")
+    client.subscribe("/v3/wireless-module/3/battery")
+
     client.connect(broker_address)
     client.loop_start()
-
     client.loop_stop()

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -54,7 +54,7 @@ def on_message(client, userdata, msg):
         record_low_battery(msg)
 
     # Record other data (battery and sensor data)
-    elif is_recording[module_id] is True:
+    elif is_recording[module_id]:
         DataToTempCSV(msg, module_start_time[module_id], module_id)
 
 

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -66,6 +66,7 @@ def on_message(client, userdata, msg):
 
 
 def start_recording(msg, module_id):
+    """ Start recording for a specific module """
     # Clear the old temporary files in the folder, just in case the script
     # exited early and they were not cleared properly
     remove_files(find_temp_csvs(module_id))
@@ -80,6 +81,7 @@ def start_recording(msg, module_id):
 
 
 def stop_recording(module_id):
+    """ Stop recording for a specific module """
     # Change the state of recording to false in global dict
     is_recording[module_id] = False
 
@@ -88,6 +90,7 @@ def stop_recording(module_id):
 
 
 def record_low_battery(msg):
+    """ Record the low battery data for on message """
     module_data = msg.payload.decode("utf-8")
     module_data = json.loads(module_data)
     module_id = "M" + module_data["module-id"]

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -43,12 +43,19 @@ def on_message(client, userdata, msg):
     # Check to see if the topic ends in "data", selecting only the msg's that
     # have wireless_module_data
     if msg.topic[:19] == "/v3/wireless-module" and msg.topic[-4:] == "data":
-        parse_wireless_module_data(msg.payload)
+        parse_wireless_module_data(msg)
 
 
-def parse_wireless_module_data(msg_payload):
-    module_data = msg_payload.decode("utf-8")
+def parse_wireless_module_data(msg):
+    module_data = msg.payload.decode("utf-8")
     module_data = json.loads(module_data)
+    sensor_data = module_data["sensors"]
+    for sensor in sensor_data:
+        sensor_type = sensor["type"]
+        sensor_value = sensor["value"]
+
+    # print(sensor_data)
+    # print(module_data)
 
 
 if __name__ == "__main__":
@@ -57,7 +64,6 @@ if __name__ == "__main__":
 
     client.on_connect = on_connect
     client.on_message = on_message
-
 
     client.connect(broker_address)
 

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -6,12 +6,12 @@ from DataToTempCSV import DataToTempCSV
 import json
 
 
-def on_connect(client, userdata, flags, rc):
-    remove_temps(find_temp_csvs())  # Remove old temp files
+def on_connect(client, userdata, flags, rc):]
+    # Remove old temp files
+    remove_temps(find_temp_csvs())
 
     if rc == 0:
         print("Connected Successfully! Result code: " + str(rc))
-
     else:
         print("Something went wrong! Result code: " + str(rc))
 

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -5,6 +5,7 @@ import paho.mqtt.client as mqtt
 import os
 from datetime import datetime
 import pandas as pd
+from DataToTempCSV import DataToTempCSV
 
 """
 FIX THE "wireless-sensor" --> "wireless-module"
@@ -57,10 +58,12 @@ def on_message(client, userdata, msg):
 
     # Check to see if the topic ends in "data", selecting only the msg's that
     # have wireless_module_data
-    if msg.topic[:18] == "v3/wireless-sensor" and msg.topic[-4:] == "data":
-        data_dict = parse_wireless_module_data(msg)
-        temp_csv(msg.topic[19], data_dict)
+    # if msg.topic[:18] == "v3/wireless-sensor" and msg.topic[-4:] == "data":
+    #     data_dict = parse_wireless_module_data(msg)
+    #     temp_csv(msg, data_dict)
+    #     print(msg.payload.decode("utf-8"))
 
+    DataToTempCSV(msg)
 
 def merge_temps(output_filename):
     """Searches throught the current directory and finds all the temp files and
@@ -116,10 +119,11 @@ def parse_wireless_module_data(msg):
     return data_dict
 
 
-def temp_csv(data_name, data_dict):
+def temp_csv(msg, data_dict):
     # make sure that the temp file is
     current_dir = os.path.dirname(__file__)
-    temp_file_path = os.path.join(current_dir, str('.~temp_' + data_name + '.csv'))
+    temp_filename = msg.topic.replace('/', '-')
+    temp_file_path = os.path.join(current_dir, str('.~temp_' + temp_filename + '.csv'))
 
     fieldnames = []
     for key in data_dict.keys():

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -12,3 +12,28 @@ import paho.mqtt.client as mqtt
 # NOTE: The battery will be implemented later. Just do the key data first.
 
 """
+
+
+def on_connect(client, userdata, flags, rc):
+    if rc == 0:
+        print("Connected Sucessfully! Result code: " + str(rc))
+    else:
+        print("Something went wrong! Result code: " + str(rc))
+
+
+def on_message(client, userdata, msg):
+    print(msg.topic+" "+str(msg.payload.decode("utf-8")))
+
+
+if __name__ == "__main__":
+    # Subscribe to all of data topics
+    broker_address = 'localhost'
+    client = mqtt.Client()
+
+    client.on_connect = on_connect
+    client.on_message = on_message
+
+    client.connect(broker_address)
+    client.loop_start()
+
+    client.loop_stop()

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -6,6 +6,15 @@ import json
 from datetime import datetime
 
 
+# Global dicts to store state
+# Dict structure is {<module_id> : <data>}
+is_recording = {}       # If the data is being recorded
+module_start_time = {}  # When the data started being recorded
+output_filename = {}    # Output filename
+
+broker_address = 'localhost'
+
+
 def on_connect(client, userdata, flags, rc):
     """ When the MQTT client connects to the broker it prints out if it
     connects successfully and then subscribes to all of the wireless-module
@@ -60,7 +69,7 @@ def on_message(client, userdata, msg):
     elif msg.topic == "/v3/wireless-module/battery/low":
         module_data = msg.payload.decode("utf-8")
         module_data = json.loads(module_data)
-        module_id = "M" + str(module_data["module-id"])
+        module_id = "M" + module_data["module-id"]
 
         DataToTempCSV(msg, module_start_time[module_id], module_id)
 
@@ -135,13 +144,6 @@ def merge_temps(output_filename, temp_filepaths):
 
 
 if __name__ == "__main__":
-    # Global dicts to store state
-    # Dict structure is {<module_id> : <data>}
-    is_recording = {}       # If the data is being recorded
-    module_start_time = {}  # When the data started being recorded
-    output_filename = {}    # Output filename
-
-    broker_address = 'localhost'
     client = mqtt.Client()
 
     client.on_connect = on_connect

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -108,13 +108,19 @@ def remove_files(filepaths):
 
 
 def merge_temps(output_filename, temp_filepaths):
-    temps_dataframes = []
+    """ This function merges multiple temporary module CSVs into a final one
+    and names the file correctly.
+    output_filename:    The name of the csv that is generated (String)
+    temp_filepaths:     Example list of filepaths is [filepath1, filepath2]"""
+
+    # Place all of the pandas dataframes into a list
+    temp_dataframes = []
     for temp_filename in temp_filepaths:
-        temp_df = pd.read_csv(temp_filename)
-        temps_dataframes.append(temp_df)
+        df = pd.read_csv(temp_filename)
+        temp_dataframes.append(df)
 
-    merged_dataframe = pd.concat(temps_dataframes, axis=1)
-
+    # Merge the dataframes and output the final csv
+    merged_dataframe = pd.concat(temp_dataframes, axis=1)
     merged_dataframe.to_csv(output_filename)
 
 

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -57,19 +57,6 @@ def parse_wireless_module_data(msg):
         sensor_type = sensor["type"]
         sensor_value = sensor["value"]
 
-        # with open(filename, mode='a') as csv_file:
-        #
-        #     fieldnames = ['co2', 'temperature', 'humidity', 'accelerometer', 'gyroscope']
-        #     writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
-        #
-        #     writer.writeheader()
-        #     writer.writerow({sensor_type: sensor_value})
-        #     # writer.writerow({'dept': 'IT', 'birth_month': 'March', 'emp_name': 'Erica Meyers'})
-
-
-    # print(sensor_data)
-    # print(module_data)
-
 
 def temp_csv(data_name, data_dict):
     # make sure that the temp file is

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -4,7 +4,7 @@ import pandas as pd
 from DataToTempCSV import DataToTempCSV
 import json
 from datetime import datetime
-
+import argparse
 
 # Global dicts to store state
 # Dict structure is {<module_id> : <data>}
@@ -12,7 +12,14 @@ is_recording = {}       # If the data is being recorded
 module_start_time = {}  # When the data started being recorded
 output_filename = {}    # Output filename
 
-broker_address = 'localhost'
+
+parser = argparse.ArgumentParser(
+    description='MQTT wireless logger',
+    add_help=True)
+parser.add_argument(
+    '--host', action='store', type=str, default="localhost",
+    help="""Address of the MQTT broker. If nothing is selected it will
+    default to localhost.""")
 
 
 def on_connect(client, userdata, flags, rc):
@@ -154,6 +161,8 @@ def merge_temps(output_filename, temp_filepaths):
 
 
 if __name__ == "__main__":
+    args = parser.parse_args()
+    broker_address = args.host
     client = mqtt.Client()
 
     client.on_connect = on_connect

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -35,29 +35,29 @@ def on_message(client, userdata, msg):
         start_data = msg.payload.decode("utf-8")
         start_data = json.loads(start_data)
 
-        # Set the module to recording in the 'is_recording' dict
+        # Save the state of recording and the output filename to global dicts
         is_recording[module_id] = True
-        # ######Set the module to recording in the 'is_recording' dict
         output_filename[module_id] = start_data["filename"]
 
         print(module_id, "STARTED")
 
     # Stop the recording of <module_id>
     elif msg.topic.endswith("stop"):
-        # Update is_recording to stop the recording of the wireless module
+        # Change the state of recording to false in global dict
         is_recording[module_id] = False
+
         print(module_id, "STOPPED")
 
-        # Save the temporary data into a perminent CSV
+        # Save the temp CSV data into a proper CSV
         save_temp_csv(module_id)
 
-    else:
-        # low battery
-        if msg.topic == "/v3/wireless-module/battery/low":
-            DataToTempCSV(msg)
-        # low battery just record normal data
-        elif is_recording[module_id] is True:
-            DataToTempCSV(msg, module_id)
+    # Record low battery data
+    elif msg.topic == "/v3/wireless-module/battery/low":
+        DataToTempCSV(msg)
+
+    # Record other data
+    elif is_recording[module_id] is True:
+        DataToTempCSV(msg, module_id)
 
 
 def save_temp_csv(module_id):

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -28,7 +28,7 @@ def on_message(client, userdata, msg):
     temp files.
     """
 
-    module_id = "M" + str(msg.topic[20])
+    module_id = "M" + msg.topic.split("/")[3]
 
     # Start the recording of <module_id>
     if msg.topic.endswith("start"):

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -6,43 +6,25 @@ from DataToTempCSV import DataToTempCSV
 import json
 
 
-def on_connect(client, userdata, flags, rc):]
-    # Remove old temp files
-    remove_temps(find_temp_csvs())
+def on_connect(client, userdata, flags, rc):
+    """ When the MQTT client connects to the broker it prints out if it
+    connects successfully and then subscribes to all of the wireless-module
+    topics"""
 
     if rc == 0:
         print("Connected Successfully! Result code: " + str(rc))
     else:
         print("Something went wrong! Result code: " + str(rc))
 
-    subscribe_to_all(client)
-
-
-def subscribe_to_all(client):
-    # Subscribe to all of the data topics
-    client.subscribe("/v3/wireless-module/1/data")
-    client.subscribe("/v3/wireless-module/2/data")
-    client.subscribe("/v3/wireless-module/3/data")
-
-    # Subscribe to all of the battery topics
-    client.subscribe("/v3/wireless-module/battery/low")
-    client.subscribe("/v3/wireless-module/1/battery")
-    client.subscribe("/v3/wireless-module/2/battery")
-    client.subscribe("/v3/wireless-module/3/battery")
-
-    # Subscribe to all of the start topics
-    client.subscribe("/v3/wireless-module/1/start")
-    client.subscribe("/v3/wireless-module/2/start")
-    client.subscribe("/v3/wireless-module/3/start")
-
-    # Subscribe to all of the stop topics
-    client.subscribe("/v3/wireless-module/1/stop")
-    client.subscribe("/v3/wireless-module/2/stop")
-    client.subscribe("/v3/wireless-module/3/stop")
+    # Subscribe to all of the wireless module topics
+    client.subscribe("/v3/wireless-module/#")
 
 
 def on_message(client, userdata, msg):
-    module_id = str("M" + msg.topic[20])
+
+    # Module ID will be a number with a capital M infrom of it.
+    # eg M1, M2, M3...
+    module_id = "M" + str(msg.topic[20])
     if msg.topic.endswith("start"):
         # Decode the data as utf-8 and load into python dict
         start_data = msg.payload.decode("utf-8")
@@ -74,7 +56,7 @@ def save_temp_csv(module_id):
     output_filename = is_recording[module_id + "_filename"]
     temp_filepaths = find_temp_csvs(module_id)
     merge_temps(output_filename, temp_filepaths)
-    remove_temps(temp_filepaths)
+    remove_files(temp_filepaths)
 
 
 def find_temp_csvs(module_id=""):
@@ -99,7 +81,7 @@ def find_temp_csvs(module_id=""):
     return temp_filepaths
 
 
-def remove_temps(filepaths):
+def remove_files(filepaths):
     """ Removes the files in the list of filepaths """
     for file in filepaths:
         os.remove(file)
@@ -117,6 +99,8 @@ def merge_temps(output_filename, temp_filepaths):
 
 
 if __name__ == "__main__":
+    remove_files(find_temp_csvs())
+
     is_recording = {
         "M1": False,
         "M2": False,

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -17,35 +17,30 @@ def on_connect(client, userdata, flags, rc):
 
 
 def subscribe_to_all(client):
-    # TODO: FIX THE TOPICS TO SPEC
-    # TODO: ADD THE CORRECT '/'
-
     # Subscribe to all of the data topics
-    client.subscribe("v3/wireless-sensor/1/data")
-    client.subscribe("v3/wireless-sensor/2/data")
-    client.subscribe("v3/wireless-sensor/3/data")
+    client.subscribe("/v3/wireless-module/1/data")
+    client.subscribe("/v3/wireless-module/2/data")
+    client.subscribe("/v3/wireless-module/3/data")
 
     # Subscribe to all of the battery topics
-    client.subscribe("v3/wireless-sensor/battery/low")
-    client.subscribe("v3/wireless-sensor/1/battery")
-    client.subscribe("v3/wireless-sensor/2/battery")
-    client.subscribe("v3/wireless-sensor/3/battery")
+    client.subscribe("/v3/wireless-module/battery/low")
+    client.subscribe("/v3/wireless-module/1/battery")
+    client.subscribe("/v3/wireless-module/2/battery")
+    client.subscribe("/v3/wireless-module/3/battery")
 
     # Subscribe to all of the start topics
-    client.subscribe("v3/wireless-module/1/start")
-    client.subscribe("v3/wireless-module/2/start")
-    client.subscribe("v3/wireless-module/3/start")
+    client.subscribe("/v3/wireless-module/1/start")
+    client.subscribe("/v3/wireless-module/2/start")
+    client.subscribe("/v3/wireless-module/3/start")
 
     # Subscribe to all of the stop topics
-    client.subscribe("v3/wireless-module/1/stop")
-    client.subscribe("v3/wireless-module/2/stop")
-    client.subscribe("v3/wireless-module/3/stop")
+    client.subscribe("/v3/wireless-module/1/stop")
+    client.subscribe("/v3/wireless-module/2/stop")
+    client.subscribe("/v3/wireless-module/3/stop")
 
 
 def on_message(client, userdata, msg):
-    # TODO: FIX THE TOPICS TO SPEC
-    # TODO: ADD THE CORRECT '/'
-    module_id = str("M" + msg.topic[19])
+    module_id = str("M" + msg.topic[20])
     if msg.topic.endswith("start"):
         # Decode the data as utf-8 and load into python dict
         start_data = msg.payload.decode("utf-8")
@@ -56,10 +51,6 @@ def on_message(client, userdata, msg):
         is_recording[module_id + "_filename"] = start_data["filename"]
         print(module_id, "STARTED")
 
-        # mosquitto_pub -h localhost -t v3/wireless-module/1/start -m '{"filename": "blk1.csv"}'
-        # mosquitto_pub -h localhost -t v3/wireless-module/1/stop -m ''
-        # mosquitto_pub -h localhost -t v3/wireless-sensor/battery/low -m '{"module-id": 1}'
-
     elif msg.topic.endswith("stop"):
         # Update is_recording to stop the recording of the wireless module
         is_recording[module_id] = False
@@ -67,23 +58,18 @@ def on_message(client, userdata, msg):
 
         # Save the temporary data into CSV
         save_temp_csv(module_id)
-        print(module_id, "SAVED")
 
     else:
-        if msg.topic == "v3/wireless-sensor/battery/low":
+        if msg.topic == "/v3/wireless-module/battery/low":
             DataToTempCSV(msg)
         elif is_recording[module_id] is True:
             DataToTempCSV(msg, module_id)
 
 
 def save_temp_csv(module_id):
-    print(module_id)
     output_filename = is_recording[module_id + "_filename"]
-    print(output_filename)
     temp_filepaths = find_temp_csvs(module_id)
-    print(temp_filepaths)
     merge_temps(output_filename, temp_filepaths)
-    # remove_temps(temp_filepaths)
 
 
 def find_temp_csvs(module_id=""):
@@ -126,22 +112,21 @@ def merge_temps(output_filename, temp_filepaths):
 
 
 if __name__ == "__main__":
-    save_temp_csv("M1")
-    # is_recording = {
-    #     "M1": False,
-    #     "M2": False,
-    #     "M3": False,
-    #     "M1_filename": None,
-    #     "M2_filename": None,
-    #     "M2_filename": None,
-    # }
-    #
-    # broker_address = 'localhost'
-    # client = mqtt.Client()
-    #
-    # client.on_connect = on_connect
-    # client.on_message = on_message
-    #
-    # client.connect(broker_address)
-    #
-    # client.loop_forever()
+    is_recording = {
+        "M1": False,
+        "M2": False,
+        "M3": False,
+        "M1_filename": None,
+        "M2_filename": None,
+        "M2_filename": None,
+    }
+
+    broker_address = 'localhost'
+    client = mqtt.Client()
+
+    client.on_connect = on_connect
+    client.on_message = on_message
+
+    client.connect(broker_address)
+
+    client.loop_forever()

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -4,6 +4,7 @@ import argparse
 import paho.mqtt.client as mqtt
 import os
 from datetime import datetime
+import pandas as pd
 
 """
 # USE 3 TEMP CSV and then merge at the end
@@ -25,6 +26,10 @@ def on_connect(client, userdata, flags, rc):
     else:
         print("Something went wrong! Result code: " + str(rc))
 
+    subscribe_to_all(client)
+
+
+def subscribe_to_all(client):
     # Subscribe to all of the data topics
     client.subscribe("/v3/wireless-module/1/data")
     client.subscribe("/v3/wireless-module/2/data")
@@ -53,8 +58,8 @@ def on_message(client, userdata, msg):
 
 
 def merge_temps(output_filename):
-    """Searches throught the current directory and finds all the temp files and merges them
-    it finds a """
+    """Searches throught the current directory and finds all the temp files and
+    merges them it finds a """
     current_dir = os.path.dirname(__file__)
     filenames = os.listdir(current_dir)
 
@@ -62,55 +67,27 @@ def merge_temps(output_filename):
 
     for filename in filenames:
         # Find the temp files and store in the array
-        if filename[-4:]==".csv" and filename[:6]==".~temp":
+        if filename[-4:] == ".csv" and filename[:6] == ".~temp":
             temp_filenames.append(current_dir + '/' + filename)
 
-    merge_temps_continued(output_filename, temp_filenames)
-
-def merge_temps_continued(output_filename, temp_filenames):
-    end_of_csv = False
-    current_line_num = 0
-    while not end_of_csv:
-
-        merged_csv_fieldnames = []
-        current_merged_dict = {}
-        current_dir = os.path.dirname(__file__)
-        merged_csv_path = os.path.join(current_dir, str(output_filename + '.csv'))
-
-        for filename in temp_filenames:
-            csv_file = open(filename, mode='r')
-            csv_reader = csv.reader(csv_file, delimiter=',')
-
-            line_count = 0
-            for row in csv_reader:
-                if line_count == 0:
-
-                    print(row)
-                else:
-                    print('0')
-
-                line_count += 1
-                # for_row_num
-                #
-                # current_row_num
-                # # First line
-                # if line_num == 0:
-                #
-                #
-                #     print('HEADERS -->', )
-                # else:
-                #     for i in range(line_num):
-                #         if i == line_num:
-                #             print()
-
-        end_of_csv = True
+    merge_temps_pandas(output_filename, temp_filenames)
 
 
-        #write to merged csv
-        with open(merged_csv_path, mode='a') as csv_file:
-            csv_writer = csv.DictWriter(csv_file, fieldnames=merged_csv_fieldnames)
-            csv_writer.writeheader()
-            csv_writer.writerow(current_merged_dict)
+def merge_temps_pandas(output_filename, temp_filenames):
+    df_array = []
+    df_columns = []
+    dataframe = pd.DataFrame()
+    print(dataframe)
+    for temp_filename in temp_filenames:
+
+        temp = pd.read_csv(temp_filename)
+        for column in temp.columns:
+            print('-->',str(column))
+            dataframe[str(column)] = temp[column]
+
+
+    print(dataframe)
+    dataframe.to_csv("aaaa.csv")
 
 
 def parse_wireless_module_data(msg):
@@ -159,6 +136,21 @@ def temp_csv(data_name, data_dict):
 
 if __name__ == "__main__":
     merge_temps('merged_output')
+    # mydictionary = {'names': ['Somu', 'Kiku', 'Amol', 'Lini'],
+	# 'physics': [68, 74, 77, 78],
+	# 'chemistry': [84, 56, 73, 69],
+	# 'algebra': [78, 88, 82, 87]}
+    #
+    # #create dataframe
+    # df_marks = pd.DataFrame(mydictionary)
+    # print('Original DataFrame\n--------------')
+    # print(df_marks)
+    #
+    # #add column
+    # df_marks['geometry'] = [81, 92, 67, 76]
+    # print('\n\nDataFrame after adding "geometry" column\n--------------')
+    # print(df_marks)
+
     # broker_address = 'localhost'
     # client = mqtt.Client()
     #
@@ -167,4 +159,4 @@ if __name__ == "__main__":
     #
     # client.connect(broker_address)
     #
-    # client.loop_forever()
+    # client.loop_forever()\\

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -64,7 +64,7 @@ def on_message(client, userdata, msg):
 
         DataToTempCSV(msg, module_start_time[module_id], module_id)
 
-    # Record other data
+    # Record other data (battery and sensor data)
     elif is_recording[module_id] is True:
         DataToTempCSV(msg, module_start_time[module_id], module_id)
 

--- a/Raspi/Test/mqtt_wireless_log.py
+++ b/Raspi/Test/mqtt_wireless_log.py
@@ -79,7 +79,7 @@ def on_message(client, userdata, msg):
         is_recording[module_id] = False
         print(module_id, "STOPPED")
 
-        # Save the temporary data into CSV with the name denoted by the filename
+        # Save the temporary data into CSV
         save_temp_csv(module_id)
         print(module_id, "SAVED")
 
@@ -91,41 +91,51 @@ def on_message(client, userdata, msg):
 
 
 def save_temp_csv(module_id):
-    filename = is_recording[module_id + "_filename"]
-    x = find_temp_csvs(module_id)
-
-    print(filename)
-    print(x)
-
-
+    print(module_id)
+    output_filename = is_recording[module_id + "_filename"]
+    print(output_filename)
+    temp_filenames = find_temp_csvs(module_id)
+    print(temp_filenames)
+    merge_temps(output_filename, temp_filenames)
+    remove_temps(temp_filenames)
+    # print(filename)
+    # print(temp_filenames)
 
 
 def find_temp_csvs(module_id=""):
     """Searches throught the current directory and finds all the temp files and
     merges them it finds a """
     current_dir = os.path.dirname(__file__)
-    filenames = os.listdir(current_dir)
+
+    if current_dir == '':
+        filenames = os.listdir()
+    else:
+        filenames = os.listdir(current_dir)
 
     temp_filenames = []
-
     for filename in filenames:
-        # Find the temp files and store in the array
+        # Find the temp filepaths and store in the array
         if filename.startswith(".~temp_" + module_id) and filename.endswith(".csv"):
-            temp_filenames.append(current_dir + '/' + filename)
+            if current_dir == '':
+                temp_filenames.append(filename)
+            else:
+                temp_filenames.append(current_dir + '/' + filename)
 
     return temp_filenames
-    # merge_temps_pandas(output_filename, temp_filenames)
 
 
-def merge_temps_pandas(output_filename, temp_filenames):
-    df_array = []
-    df_columns = []
+def remove_temps(filenames):
+    for file in filenames:
+        os.remove(file)
+
+
+def merge_temps(output_filename, temp_filenames):
+    return
     dataframe = pd.DataFrame()
     for temp_filename in temp_filenames:
 
         temp = pd.read_csv(temp_filename)
         for column in temp.columns:
-            print('-->',str(column))
             dataframe[str(column)] = temp[column]
 
     dataframe.to_csv(output_filename)


### PR DESCRIPTION
## Description
This pull request adds code to be able to log the data received from the wireless modules. It listens on localhost and records data when it is sent out on the MQTT data and battery topics. It waits for the start topic on MQTT to start.

`/v3/wireless-module/<id>/start`

And continues recording until the stop signal on

`/v3/wireless-module/<id>/stop`

It then outputs the recorded data and battery stats into a CSV file for the specified module. 

## Screenshots

<img width="295" alt="Screen Shot 2020-01-27 at 1 30 28 pm" src="https://user-images.githubusercontent.com/23159604/73146977-541e3b80-4109-11ea-882f-68fa7e070178.png">

Prints when certain modules are started and stopped. When it is stopped it is saved.

## Steps to Test

To run the logger use `python3 mqtt_wireless_log.py`
This will save the logs to the directory where you run the command