### PR TITLE
Add reed distance to fake_module_tester

### DIFF
--- a/DAS/das/tests/fake_module_tester.py
+++ b/DAS/das/tests/fake_module_tester.py
@@ -34,6 +34,7 @@ sensors = {
     "temperature": MockSensor(25),
     "humidity": MockSensor(85),
     "reedVelocity": MockSensor(50),
+    "reedDistance": MockSensor(1000),
     "battery": MockSensor(80),
     "accelerometer": MockSensor(("x", 90),
                                 ("y", 90),
@@ -55,7 +56,7 @@ sensors = {
 # HARDCODED MODULE ONBOARD SENSORS (dict above contains the MockSensor objects)
 M1_sensors = ["temperature", "humidity", "steeringAngle"]
 M2_sensors = ["co2", "temperature", "humidity", "accelerometer", "gyroscope"]
-M3_sensors = ["co2", "reedVelocity", "gps"]
+M3_sensors = ["co2", "reedVelocity", "reedDistance", "gps"]
 M4_sensors = ["power", "cadence", "heartRate"]
 Mn_sensors = list(sensors.keys())  # For other fake module all sensors are used
 


### PR DESCRIPTION
## Description

Somehow we missed adding reed distance to a bunch of V3 things. Whoops! This PR makes `fake_module_tester.py` publish fake reed distance info. It's not monotonic like real data but it should be fine.

## Screenshots

![image](https://user-images.githubusercontent.com/17876556/92988129-3375eb00-f50c-11ea-8a2a-1d78964c7b1b.png)

## Steps to Test

`python DAS/das/tests/fake_module/tester.py -t 5` and `mosquitto_sub -t "/v3/wireless-module/3/data"`
