### PR TITLE
Refactor ESP32 file upload script

### DIFF
--- a/wireless_modules/middle_module/README.md
+++ b/wireless_modules/middle_module/README.md
@@ -16,12 +16,18 @@ This repository contains all the code related to Monash Human Power's middle wir
 
 ```
 # Change the first argument to the serial port of the ESP32.
+# This would upload all files relevant to this wireless module onto the board
 ./upload.sh /dev/ttyUSB0 
+
+                            OR
+                            
+# To upload only specific files list their path after the port name argument
+./upload.sh /dev/ttyUSB0 file1 ../file2 ... fileN
 ```
 
 ## Contents
 - `main.py`: Declares topics to publish and subscribe to
-- `mpu.py`: Class that helps read data from the MPU6050 sensor
+- `upload.sh`: File to upload specific or all relevant files onto the ESP32 automatically 
 - `test.py`: A python script to test the sensor data received from the middle wireless module over MQTT
 
 

--- a/wireless_modules/middle_module/README.md
+++ b/wireless_modules/middle_module/README.md
@@ -16,7 +16,7 @@ This repository contains all the code related to Monash Human Power's middle wir
 
 ```
 # Change the first argument to the serial port of the ESP32.
-# This would upload all files relevant to this wireless module onto the board
+# This would upload all files relevant to the middle wireless module onto the board
 ./upload.sh /dev/ttyUSB0 
 
                             OR

--- a/wireless_modules/middle_module/upload.sh
+++ b/wireless_modules/middle_module/upload.sh
@@ -2,6 +2,14 @@
 
 # Note: Shell scripting should have no white space between the '=' operator for variable assigning
 
+# declares an integer
+declare -i BAUD_RATE=115200
+
+PORT=$1
+files="main.py ../config.py ../wireless_module.py  ../boot.py ../mqtt_client.py ../sensors/mpu.py \
+../sensors/dht_sensor.py ../sensors/co2_sensor.py ../libraries/MQ135/mq135.py ../sensors/sensor_base.py \
+../libraries/abc.py ../libraries/MPU6050-ESP8266-MicroPython/mpu6050.py"
+
 # Check that the port name is specified in the argument
 if [ $# -eq 0 ]
 then   
@@ -9,24 +17,50 @@ then
     exit 1
 fi
 
+# Function to upload file on ESP32
+upload_file()
+{
+    # Parameters:
+    # $1 (First argument to this function): The relative path of the file to upload
 
-# declares an integer
-declare -i BAUD_RATE=115200
+    # Place file on the board
+    ampy -p $PORT -b $BAUD_RATE put $1
 
-files="main.py ../config.py ../wireless_module.py  ../boot.py ../mqtt_client.py ../sensors/mpu.py \
-../sensors/dht_sensor.py ../sensors/co2_sensor.py ../libraries/MQ135/mq135.py ../sensors/sensor_base.py \
-../libraries/abc.py ../libraries/MPU6050-ESP8266-MicroPython/mpu6050.py"
-
-for file in $files
-do 
-    # Places file on the ESP32
-    ampy -p $1 -b $BAUD_RATE put $file
-
-    # '$?' stores 0 if the above command ran successfully
+    # $? holds 0 if the last command executed ran successfully
     if [ $? == 0 ]
     then
-        echo "$file loaded"
+        echo "$1 loaded"
     else
-        echo "$file NOT loaded"
+        echo "$1 NOT loaded"
     fi
-done
+}
+
+# If there are more than 1 command line arguments, user has specified the files to upload in the arguments
+if [ $# -gt 1 ]
+then
+    i=1
+    # loop through each argument list and upload the file onto the board
+    for arg
+    do
+        # If this is the first argument, ignore since it's the port name
+        if [ $i -eq 1 ]
+        then
+            i=2
+
+        else
+            # Invoke function and pass arguments ($arg is the file name)
+            upload_file $arg
+        fi
+    done
+
+else
+    # Upload all the default files listed under the files variable
+    for file in $files
+    do
+        # Invoke function and pass $file as the argument
+        upload_file $file
+    done
+fi
+
+# Print black line at the end of execution
+echo ""

--- a/wireless_modules/middle_module/upload.sh
+++ b/wireless_modules/middle_module/upload.sh
@@ -1,18 +1,21 @@
 #!/bin/sh
 
-# Check that the port name is specified in the argumennt
+# Note: Shell scripting should have no white space between the '=' operator for variable assigning
+
+# Check that the port name is specified in the argument
 if [ $# -eq 0 ]
 then   
     echo "Port name not specified after ./upload.sh command"
     exit 1
 fi
 
-# Shell scripting should have no white space between the '=' operator for variable asisgning
 
 # declares an integer
 declare -i BAUD_RATE=115200
 
-files="config.py ../wireless_module.py"
+files="main.py ../config.py ../wireless_module.py  ../boot.py ../mqtt_client.py ../sensors/mpu.py \
+../sensors/dht_sensor.py ../sensors/co2_sensor.py ../libraries/MQ135/mq135.py ../sensors/sensor_base.py \
+../libraries/abc.py ../libraries/MPU6050-ESP8266-MicroPython/mpu6050.py"
 
 for file in $files
 do 
@@ -27,4 +30,3 @@ do
         echo "$file NOT loaded"
     fi
 done
-

--- a/wireless_modules/middle_module/upload.sh
+++ b/wireless_modules/middle_module/upload.sh
@@ -1,25 +1,23 @@
 #!/bin/sh
-ampy -p $1 -b 115200 put ../config.py
-echo "config.py loaded"
-ampy -p $1 -b 115200 put main.py
-echo "main.py loaded"
-ampy -p $1 -b 115200 put ../boot.py
-echo "boot.py loaded"
-ampy -p $1 -b 115200 put ../mqtt_client.py
-echo "mqtt_client.py loaded"
-ampy -p $1 -b 115200 put ../wireless_module.py
-echo "wireless_module.py loaded"
-ampy -p $1 -b 115200 put ../libraries/MPU6050-ESP8266-MicroPython/mpu6050.py
-echo "mpu6050.py loaded"
-ampy -p $1 -b 115200 put ../sensors/mpu.py
-echo "mpu.py loaded"
-ampy -p $1 -b 115200 put ../sensors/dht_sensor.py
-echo "dht_sensor.py loaded"
-ampy -p $1 -b 115200 put ../sensors/co2_sensor.py
-echo "mq135_sensor.py loaded"
-ampy -p $1 -b 115200 put ../libraries/MQ135/mq135.py
-echo "mq135.py loaded"
-ampy -p $1 -b 115200 put ../sensors/sensor_base.py
-echo "sensor_base.py loaded"
-ampy -p $1 -b 115200 put ../libraries/abc.py
-echo "abc.py loaded"
+
+# Shell scripting should have no white space between the '=' operator for variable asisgning
+
+# declares an integer
+declare -i BAUD_RATE=115200
+
+files="config.py ../wireless_module.py"
+
+for file in $files
+do 
+    # Places file on the ESP32
+    ampy -p $1 -b $BAUD_RATE put $file
+
+    # '$?' stores 0 if the above command ran successfully
+    if [ $? == 0 ]
+    then
+        echo "$file loaded"
+    else
+        echo "$file NOT loaded"
+    fi
+done
+

--- a/wireless_modules/middle_module/upload.sh
+++ b/wireless_modules/middle_module/upload.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# Check that the port name is specified in the argumennt
+if [ $# -eq 0 ]
+then   
+    echo "Port name not specified after ./upload.sh command"
+    exit 1
+fi
+
 # Shell scripting should have no white space between the '=' operator for variable asisgning
 
 # declares an integer

--- a/wireless_modules/middle_module/upload.sh
+++ b/wireless_modules/middle_module/upload.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
+# Purpose: To upload specific files or all relevant middle wireless module files (default) onto the ESP32
+# Requirements: Must have ampy downloaded
+
 # NOTE: 
 # Shell scripting should have no white space between the '=' operator for variable assigning
-# $# is the number of arguments given through the command line
-# $arg variable is a list of all arguments passed through the command line
 
 # declares an integer
 declare -i BAUD_RATE=115200
@@ -21,7 +22,7 @@ then
     exit 1
 fi
 
-# Function to upload file on ESP32
+# Function to upload file onto the board
 upload_file()
 {
     # Parameters:
@@ -43,7 +44,7 @@ upload_file()
 if [ $NUM_ARGS -gt 1 ]
 then
     i=1
-    # loop through each argument list and upload the file onto the board
+    # loop through each argument provided and upload the file given onto the board
     for arg
     do
         # If this is the first argument, ignore since it's the port name
@@ -52,7 +53,7 @@ then
             i=2
 
         else
-            # Invoke function and pass arguments ($arg is the file name)
+            # Invoke function and pass file name as argument
             upload_file $arg
         fi
     done
@@ -66,5 +67,5 @@ else
     done
 fi
 
-# Print black line at the end of execution
+# Print black line at the end of execution for readability
 echo ""

--- a/wireless_modules/middle_module/upload.sh
+++ b/wireless_modules/middle_module/upload.sh
@@ -11,9 +11,20 @@ declare -i BAUD_RATE=115200
 
 PORT=$1
 NUM_ARGS=$#
-files="main.py ../config.py ../wireless_module.py  ../boot.py ../mqtt_client.py ../sensors/mpu.py \
-../sensors/dht_sensor.py ../sensors/co2_sensor.py ../libraries/MQ135/mq135.py ../sensors/sensor_base.py \
-../libraries/abc.py ../libraries/MPU6050-ESP8266-MicroPython/mpu6050.py"
+files=(
+    "main.py" 
+    "../config.py" 
+    "../wireless_module.py"
+    "../boot.py"
+    "../mqtt_client.py"
+    "../sensors/sensor_base.py"
+    "../sensors/mpu.py"
+    "../sensors/dht_sensor.py"
+    "../sensors/co2_sensor.py"
+    "../libraries/abc.py"
+    "../libraries/MQ135/mq135.py"
+    "../libraries/MPU6050-ESP8266-MicroPython/mpu6050.py"
+)
 
 # Check that the port name is specified in the argument 
 if [ $NUM_ARGS -eq 0 ]
@@ -59,8 +70,8 @@ then
     done
 
 else
-    # Upload all the default files listed under the files variable
-    for file in $files
+    # Upload all the default files listed inside the files array
+    for file in ${files[@]}
     do
         # Invoke function and pass $file as the argument
         upload_file $file

--- a/wireless_modules/middle_module/upload.sh
+++ b/wireless_modules/middle_module/upload.sh
@@ -1,17 +1,21 @@
 #!/bin/sh
 
-# Note: Shell scripting should have no white space between the '=' operator for variable assigning
+# NOTE: 
+# Shell scripting should have no white space between the '=' operator for variable assigning
+# $# is the number of arguments given through the command line
+# $arg variable is a list of all arguments passed through the command line
 
 # declares an integer
 declare -i BAUD_RATE=115200
 
 PORT=$1
+NUM_ARGS=$#
 files="main.py ../config.py ../wireless_module.py  ../boot.py ../mqtt_client.py ../sensors/mpu.py \
 ../sensors/dht_sensor.py ../sensors/co2_sensor.py ../libraries/MQ135/mq135.py ../sensors/sensor_base.py \
 ../libraries/abc.py ../libraries/MPU6050-ESP8266-MicroPython/mpu6050.py"
 
-# Check that the port name is specified in the argument
-if [ $# -eq 0 ]
+# Check that the port name is specified in the argument 
+if [ $NUM_ARGS -eq 0 ]
 then   
     echo "Port name not specified after ./upload.sh command"
     exit 1
@@ -36,7 +40,7 @@ upload_file()
 }
 
 # If there are more than 1 command line arguments, user has specified the files to upload in the arguments
-if [ $# -gt 1 ]
+if [ $NUM_ARGS -gt 1 ]
 then
     i=1
     # loop through each argument list and upload the file onto the board


### PR DESCRIPTION
## Description

In my previous PR (Middle Wireless Module sensor programming) Angus had suggested to refactor the `upload.sh` file since it contained a lot of repeated code and could become painful for maintaining going froward. So this PR refactored this shell script and also added a new functionality (why not).

Learning shell scripting wasn't as tough as I'd thought but it does follow some very different syntax (obviously) and so I tried to comment the important differences which I thought would make it easier for anyone else reading it and more so for myself if I ever come back to it.

The functions that `upload.sh` performs now include:
1) Uploading all the relevant files for middle wireless module to function onto the ESP32 board if used with only one argument (The port name)
2) If file paths are specified after the port name in the command line argument, the script will ONLY upload those files onto the board (This would make it faster when you only want to upload a few changed files rather than all files which is what the script did before) 

## Screenshots

Uploading all default files:
<img width="520" alt="Screen Shot 2020-09-18 at 9 23 59 am" src="https://user-images.githubusercontent.com/63642262/93539301-b4f9cd00-f993-11ea-94ab-0461ecda1c1f.png">

Uploading with wrong file path:
<img width="569" alt="Screen Shot 2020-09-18 at 9 23 28 am" src="https://user-images.githubusercontent.com/63642262/93539330-cba02400-f993-11ea-8f0d-034e8b3c2e5b.png">

## Steps to Test

- Navigate to the `middle_module` folder
- Open terminal and try running `./upload.sh` : it shall fail and give you a friendly reminder
- Open a file used by the middle wireless module (e.g. `../libraries/abc.py`) and add some dummy code or comment at the bottom of the file (makes it easier to spot the change)
- Now type `./upload.sh <port_name>` replacing the placeholder with your port name for the ESP32 and this should upload all files onto the board and display the execution message.
- Alternatively type `./upload.sh <port_name> [files]` placing as many file paths you want updated in place of the [files] argument and the script should only upload those files.
- Use `ampy -p <port_name> -b 115200 get <file_changed>` replacing the relevant placeholders with the correct file names to view the changed files (if your change was towards the end of the file it should be easy to spot it)
