### PR TITLE
Add WM status LED

### DIFF
--- a/wireless_modules/README.md
+++ b/wireless_modules/README.md
@@ -4,13 +4,13 @@ Wireless sensor firmware based on MicroPython.
 
 ## Getting Started
 
-For an overview of the wireless module usage from a user's view, see the [notion manual](https://www.notion.so/Wireless-module-usage-manual-cd7e948418d040d991a50c91815e63e9).
+For an overview of the wireless module usage from a user's view, see the [Notion manual](https://www.notion.so/Wireless-module-usage-manual-cd7e948418d040d991a50c91815e63e9).
 
 ### Set up development environment
 
 Make sure to use Visual Studio Code for the best development experience.
 
-```
+```bash
 # Install the required tools
 pipenv install
 pipenv shell
@@ -22,11 +22,11 @@ micropy
 
 You will need to create a local version of `config.py` (`cp src/config.example.py src/config.py`) and change some settings.
 
-| Name      | Description                        |
-| --------- | ---------------------------------- |
-| SENSOR_ID | Wireless module ID                 |
-| WIFI_SSID | Name of Wifi network to connect to |
-| WIFI_PASS | Wifi password                      |
+| Name        | Description                        |
+| ----------- | ---------------------------------- |
+| MQTT_BROKER | IP address of the MQTT broker      |
+| ESSID       | Name of WiFi network to connect to |
+| PASSWORD    | WiFi password                      |
 
 ### Flashing MicroPython to the ESP32
 
@@ -34,7 +34,7 @@ The ESP32 needs to be flashed with the base micropython firmware. This only need
 
 ## Uploading Code
 The `upload.sh` file in `middle_module` folder can be used to upload all relevant files on the ESP32.
-```
+```bash
 # Change this to the serial port of the ESP32
 ./upload.sh --port /dev/ttyUSB0
 ```
@@ -50,15 +50,3 @@ If using `picocom`:
 Note: This only works once in a `picocom` session, after that you'll need to close `picocom` and repeat from step 5.
 
 Use `Control-A` and then `Control-X` to terminate `picocom`.
-
-## TODOs
-
-*To remove once you have everything done!*
-
-- [x] `.env` file
-- [ ] Linters
-- [ ] travisCI files
-- [ ] Badges
-- [ ] Linting hooks
-- [ ] Basic unit tests
-- [x] Set `master` branch protection. Only allow Squash and Merge for PR's. At least 1 approval.

--- a/wireless_modules/README.md
+++ b/wireless_modules/README.md
@@ -4,6 +4,8 @@ Wireless sensor firmware based on MicroPython.
 
 ## Getting Started
 
+For an overview of the wireless module usage from a user's view, see the [notion manual](https://www.notion.so/Wireless-module-usage-manual-cd7e948418d040d991a50c91815e63e9).
+
 ### Set up development environment
 
 Make sure to use Visual Studio Code for the best development experience.

--- a/wireless_modules/back_module/main.py
+++ b/wireless_modules/back_module/main.py
@@ -25,6 +25,9 @@ RZERO = 8.62
 # Circumference of a 700x28 bike wheel in meters.
 WHEEL_CIRCUMFERENCE = 2.136
 
+# Mutable global so we can write to the LED if a fatal error occurs
+status_led = StatusLed(STATUS_LED_PINS)
+
 # Define a function to map measured voltages to "true" voltages.
 # See util/battery_lin_reg.py
 def battery_calibration(voltage):
@@ -32,7 +35,6 @@ def battery_calibration(voltage):
 
 
 async def main():
-    status_led = StatusLed(STATUS_LED_PINS)
     status_led.set_state(WmState.InitialisingSensors)
     asyncio.create_task(status_led.start_blink_loop())
 
@@ -64,8 +66,6 @@ async def main():
     sensors = [my_dht, my_mq135, my_reed, my_gps, my_mpu]
     back_module.add_sensors(sensors)
 
-    await asyncio.sleep(5)
-
     print("Starting asyncio loop")
     asyncio.create_task(back_module.run())
 
@@ -81,5 +81,7 @@ except KeyboardInterrupt:
 except Exception as exc:
     sys.print_exception(exc)
     print("Detected crash, resetting in 5 seconds...")
+    status_led.set_warning_state(WmState.Error)
+
     time.sleep(5)
     machine.reset()

--- a/wireless_modules/back_module/main.py
+++ b/wireless_modules/back_module/main.py
@@ -3,12 +3,14 @@ import time
 import uasyncio as asyncio
 import machine
 from wireless_module import WirelessModule
+from config import STATUS_LED_PINS
 from co2_sensor import CO2
 from dht_sensor import DhtSensor
 from gps_sensor import GpsSensor
 from mpu_sensor import MpuSensor
 from reed_sensor import ReedSensor
 from battery_reader import BatteryReader
+from status_led import StatusLed, WmState
 
 
 # Define module number
@@ -29,14 +31,9 @@ def battery_calibration(voltage):
     return 0.710 * voltage + 0.927
 
 
-# Pins for R, G, B channels of status LED
-STATUS_PINS = [14, 12, 13]
-
-
 async def main():
-    for pin_num in STATUS_PINS:
-        pin = machine.Pin(pin_num, machine.Pin.OUT)
-        pin.off()
+    status_led = StatusLed(STATUS_LED_PINS)
+    status_led.set_state(WmState.InitialisingSensors)
 
     # Define all the Pin objects for each sensor
     dht_pin = machine.Pin(4)
@@ -62,7 +59,7 @@ async def main():
     battery_reader = BatteryReader(battery_pin, battery_calibration)
 
     # Set up the wireless module
-    back_module = WirelessModule(MODULE_NUM, battery_reader)
+    back_module = WirelessModule(MODULE_NUM, battery_reader, status_led)
     sensors = [my_dht, my_mq135, my_reed, my_gps, my_mpu]
     back_module.add_sensors(sensors)
 

--- a/wireless_modules/back_module/main.py
+++ b/wireless_modules/back_module/main.py
@@ -34,6 +34,7 @@ def battery_calibration(voltage):
 async def main():
     status_led = StatusLed(STATUS_LED_PINS)
     status_led.set_state(WmState.InitialisingSensors)
+    asyncio.create_task(status_led.start_blink_loop())
 
     # Define all the Pin objects for each sensor
     dht_pin = machine.Pin(4)
@@ -62,6 +63,8 @@ async def main():
     back_module = WirelessModule(MODULE_NUM, battery_reader, status_led)
     sensors = [my_dht, my_mq135, my_reed, my_gps, my_mpu]
     back_module.add_sensors(sensors)
+
+    await asyncio.sleep(5)
 
     print("Starting asyncio loop")
     asyncio.create_task(back_module.run())

--- a/wireless_modules/back_module/upload.sh
+++ b/wireless_modules/back_module/upload.sh
@@ -24,6 +24,7 @@ files=(
     "../sensors/gps_sensor.py"
     "../sensors/mpu_sensor.py"
     "../sensors/reed_sensor.py"
+    "../status_led.py"
     "../libraries/abc.py"
     "../libraries/MQ135/mq135.py"
     "../libraries/micropyGPS/micropyGPS.py"

--- a/wireless_modules/boot.py
+++ b/wireless_modules/boot.py
@@ -1,8 +1,9 @@
-
 import esp
 import network
-import config
 from machine import Pin
+
+import config
+from status_led import StatusLed, WmState
 
 
 def do_connect(essid, password):
@@ -21,16 +22,19 @@ def do_connect(essid, password):
     station_interface.connect(essid, password)
 
     # Wait for the module to connect
-    while not station_interface.isconnected(): 
+    while not station_interface.isconnected():
         pass
-    
+
     print("Connected, network config:", station_interface.ifconfig())
 
+
+status_led = StatusLed(config.STATUS_LED_PINS)
+status_led.set_state(WmState.ConnectingToNetwork)
 
 # Allows the code to be uploaded with tools such as rshell / ampy
 esp.osdebug(None)
 do_connect(config.ESSID, config.PASSWORD)
 
 # Turn on the built in LED when booted and connected to WiFi (blue light)
-builtin_LED = Pin(config.led_pin, Pin.OUT)
-builtin_LED.on()
+builtin_led = Pin(config.BUILTIN_LED_PIN, Pin.OUT)
+builtin_led.on()

--- a/wireless_modules/config.example.py
+++ b/wireless_modules/config.example.py
@@ -1,10 +1,11 @@
-from machine import Pin
-
 ESSID = "<WIFI NETWORK NAME HERE>"
 PASSWORD = "<WIFI PASSWORD HERE>"
 
 MQTT_BROKER = "<Broker domain address or IP address>"
 
-# The pin number reference to the built-in led
-led_pin = 2
+# Pins for R, G, B channels of status LED
+STATUS_LED_PINS = [14, 12, 13]
+
+# Pin for LED on ESP32 board
+BUILTIN_LED_PIN = 2
 

--- a/wireless_modules/mqtt_client.py
+++ b/wireless_modules/mqtt_client.py
@@ -1,4 +1,4 @@
-from umqtt.simple import MQTTClient
+from umqtt.simple import MQTTException, MQTTClient
 import uasyncio as asyncio
 
 
@@ -10,8 +10,9 @@ class Client:
         :param broker_address: A string holding domain name or IP address of the broker to connect to, to send and
                             receive data.
         """
-        self.client = MQTTClient(client_id, broker_address)
+        self.client = MQTTClient(client_id, broker_address, keepalive=60)
         self.mqtt_broker = broker_address
+        self.connected = False
 
     async def connect_and_subscribe(self, topics_to_subscribe, callback_func):
         """
@@ -32,8 +33,8 @@ class Client:
                 )
                 self.client.connect()
                 self.connected = True
-            except OSError as e:
-                print("Failed to connect! {}".format(e))
+            except (OSError, MQTTException) as e:
+                print("Failed to connect! {}: {}".format(type(e), e))
                 print("Reattempting in 5 seconds.")
                 await asyncio.sleep(5)
 

--- a/wireless_modules/mqtt_client.py
+++ b/wireless_modules/mqtt_client.py
@@ -12,6 +12,7 @@ class Client:
         """
         self.client = MQTTClient(client_id, broker_address)
         self.mqtt_broker = broker_address
+        self.connected = False
 
     async def connect_and_subscribe(self, topics_to_subscribe, callback_func):
         """
@@ -40,6 +41,7 @@ class Client:
                 await asyncio.sleep(5)
 
         print("Connected to {}".format(self.mqtt_broker))
+        self.connected = True
 
         # Subscribe to each topic
         for topic in topics_to_subscribe:
@@ -86,4 +88,5 @@ class Client:
         """
         Disconnect from the broker
         """
+        self.connected = False
         self.client.disconnect()

--- a/wireless_modules/mqtt_client.py
+++ b/wireless_modules/mqtt_client.py
@@ -1,4 +1,5 @@
 from umqtt.simple import MQTTClient
+import uasyncio as asyncio
 
 
 class Client:
@@ -12,7 +13,7 @@ class Client:
         self.client = MQTTClient(client_id, broker_address)
         self.mqtt_broker = broker_address
 
-    def connect_and_subscribe(self, topics_to_subscribe, callback_func):
+    async def connect_and_subscribe(self, topics_to_subscribe, callback_func):
         """
         Connects to the MQTT broker and subscribes to each topic in 'topics_to_subscribe' using QoS = 1
         :param topics_to_subscribe: An array of topics to subscribe to.
@@ -22,7 +23,22 @@ class Client:
         self.client.set_callback(callback_func)
 
         # Connect to MQTT broker
-        self.client.connect()
+        connection_success = False
+        while not connection_success:
+            connection_success = True
+            try:
+                print(
+                    "Attempting connection to MQTT broker at {}...".format(
+                        self.mqtt_broker
+                    )
+                )
+                self.client.connect()
+            except OSError as e:
+                connection_success = False
+                print("Failed to connect! {}".format(e))
+                print("Reattempting in 5 seconds.")
+                await asyncio.sleep(5)
+
         print("Connected to {}".format(self.mqtt_broker))
 
         # Subscribe to each topic

--- a/wireless_modules/mqtt_client.py
+++ b/wireless_modules/mqtt_client.py
@@ -12,7 +12,6 @@ class Client:
         """
         self.client = MQTTClient(client_id, broker_address)
         self.mqtt_broker = broker_address
-        self.connected = False
 
     async def connect_and_subscribe(self, topics_to_subscribe, callback_func):
         """
@@ -24,9 +23,7 @@ class Client:
         self.client.set_callback(callback_func)
 
         # Connect to MQTT broker
-        connection_success = False
-        while not connection_success:
-            connection_success = True
+        while not self.connected:
             try:
                 print(
                     "Attempting connection to MQTT broker at {}...".format(
@@ -34,8 +31,8 @@ class Client:
                     )
                 )
                 self.client.connect()
+                self.connected = True
             except OSError as e:
-                connection_success = False
                 print("Failed to connect! {}".format(e))
                 print("Reattempting in 5 seconds.")
                 await asyncio.sleep(5)

--- a/wireless_modules/status_led.py
+++ b/wireless_modules/status_led.py
@@ -19,7 +19,7 @@ class WmState:
     Undefined = LedState(1, 1, 1, True)
 
     ConnectingToNetwork = LedState(1, 1, 0, False)
-    InitialisingSensors = LedState(1, 0, 1, True)
+    InitialisingSensors = LedState(0, 1, 1, True)
     ConnectingToMqtt = LedState(0, 0, 1, True)
     Idle = LedState(0, 0, 1, False)
     Publishing = LedState(0, 1, 0, False)

--- a/wireless_modules/status_led.py
+++ b/wireless_modules/status_led.py
@@ -1,0 +1,36 @@
+import machine
+
+
+class LedState:
+    def __init__(self, r, g, b, blink):
+        self.r = r
+        self.g = g
+        self.b = b
+        self.blink = blink
+
+
+class WmState:
+    Undefined = LedState(1, 1, 1, True)
+    LowBattery = LedState(1, 0, 0, True)
+    ConnectingToNetwork = LedState(1, 1, 0, True)
+    ConnectingToMqtt = LedState(1, 1, 0, False)
+    InitialisingSensors = LedState(0, 0, 1, True)
+    Idle = LedState(0, 0, 1, False)
+    Publishing = LedState(0, 1, 0, False)
+
+
+class StatusLed:
+    def __init__(self, led_pins):
+        self.r_pin = machine.Pin(led_pins[0], machine.Pin.OUT)
+        self.g_pin = machine.Pin(led_pins[1], machine.Pin.OUT)
+        self.b_pin = machine.Pin(led_pins[2], machine.Pin.OUT)
+
+        self.state = None
+        self.set_state(WmState.Undefined)
+
+    def set_state(self, state):
+        if state is not self.state:
+            self.r_pin.on() if state.r else self.r_pin.off()
+            self.g_pin.on() if state.g else self.g_pin.off()
+            self.b_pin.on() if state.b else self.b_pin.off()
+            self.state = state

--- a/wireless_modules/status_led.py
+++ b/wireless_modules/status_led.py
@@ -19,7 +19,7 @@ class WmState:
     Undefined = LedState(1, 1, 1, True)
 
     ConnectingToNetwork = LedState(1, 1, 0, False)
-    InitialisingSensors = LedState(1, 1, 0, True)
+    InitialisingSensors = LedState(1, 0, 1, True)
     ConnectingToMqtt = LedState(0, 0, 1, True)
     Idle = LedState(0, 0, 1, False)
     Publishing = LedState(0, 1, 0, False)

--- a/wireless_modules/status_led.py
+++ b/wireless_modules/status_led.py
@@ -53,12 +53,12 @@ class StatusLed:
         # the calling code is blocking, the color still changes
         if state is not self.state:
             self.state = state
-            self.__set_leds_on(state)
+            self.__set_leds_on(state) if state else self.__set_leds_off()
 
     def set_warning_state(self, state):
         if state is not self.warning_state:
             self.warning_state = state
-            self.__set_leds_on(state)
+            self.__set_leds_on(state) if state else self.__set_leds_off()
 
     async def start_blink_loop(self):
         while True:

--- a/wireless_modules/status_led.py
+++ b/wireless_modules/status_led.py
@@ -58,6 +58,7 @@ class StatusLed:
     def set_warning_state(self, state):
         if state is not self.warning_state:
             self.warning_state = state
+            self.__set_leds_on(state)
 
     async def start_blink_loop(self):
         while True:

--- a/wireless_modules/wireless_module.py
+++ b/wireless_modules/wireless_module.py
@@ -93,7 +93,6 @@ class WirelessModule:
             self.status_led.set_warning_state(
                 WmState.LowBattery if battery_voltage["voltage"] <= 3.3 else None
             )
-            print(self.status_led.state, self.status_led.warning_state)
             await asyncio.sleep(interval)
 
     async def wait_for_start(self):
@@ -144,7 +143,7 @@ class WirelessModule:
 
             self.mqtt.check_for_message()
 
-    async def run(self, data_interval=1, battery_data_interval=5):
+    async def run(self, data_interval=1, battery_data_interval=300):
         """
         Start running the wireless module. Connects to MQTT and starts the data and battery loops.
         :param data_interval: Integer representing number of seconds to wait before sending data.

--- a/wireless_modules/wireless_module.py
+++ b/wireless_modules/wireless_module.py
@@ -12,6 +12,8 @@ try:
 except FileNotFoundError:
     print("Error importing config.py, ensure a local version of config.py exists")
 
+LOW_BATTERY_THRESHOLD = 3.3
+
 
 class WirelessModule:
     """
@@ -91,7 +93,7 @@ class WirelessModule:
                     self.battery_topic, ujson.dumps(battery_voltage), retain=True
                 )
             self.status_led.set_warning_state(
-                WmState.LowBattery if battery_voltage["voltage"] <= 3.3 else None
+                WmState.LowBattery if battery_voltage["voltage"] <= LOW_BATTERY_THRESHOLD else None
             )
             await asyncio.sleep(interval)
 

--- a/wireless_modules/wireless_module.py
+++ b/wireless_modules/wireless_module.py
@@ -109,7 +109,9 @@ class WirelessModule:
                     self.battery_topic, ujson.dumps(battery_voltage), retain=True
                 )
             self.status_led.set_warning_state(
-                WmState.LowBattery if battery_voltage["voltage"] <= LOW_BATTERY_THRESHOLD else None
+                WmState.LowBattery
+                if battery_voltage["voltage"] <= LOW_BATTERY_THRESHOLD
+                else None
             )
             await asyncio.sleep(interval)
 

--- a/wireless_modules/wireless_module.py
+++ b/wireless_modules/wireless_module.py
@@ -75,6 +75,27 @@ class WirelessModule:
         elif topic == self.sub_stop_topic:
             self.start_publish = False
 
+    async def start_battery_loop(self, interval):
+        """
+        Start publishing the battery voltage and if required show the battery warning
+        on the status LED.
+        :param interval: Integer representing number of seconds to wait before sending battery voltage data
+        """
+        if self.battery is None:
+            return
+
+        while True:
+            battery_voltage = self.battery.read()
+            if self.mqtt.connected:
+                self.mqtt.publish(
+                    self.battery_topic, ujson.dumps(battery_voltage), retain=True
+                )
+            self.status_led.set_warning_state(
+                WmState.LowBattery if battery_voltage["voltage"] <= 3.3 else None
+            )
+            print(self.status_led.state, self.status_led.warning_state)
+            await asyncio.sleep(interval)
+
     async def wait_for_start(self):
         """
         Asynchronously blocks until publishing is started.
@@ -95,39 +116,24 @@ class WirelessModule:
             for sensor in self.sensors:
                 sensor.on_start()
 
-    async def run(self, data_rate=1, battery_data_rate=300):
+    async def start_data_loop(self, interval):
         """
-        Start the wireless module process: Wait for start message, publish sensor data when start message
-        received and continuously check for a stop message - after which the process is repeated.
-        :param data_rate: Integer representing number of seconds to wait before sending data.
-        :param battery_data_rate: Integer representing number of seconds to wait before sending battery voltage data
+        Start the wireless module data publishing process: Wait for start message,
+        publish sensor data when start message received and continuously check for a
+        stop message - after which the process is repeated.
+        :param interval: Integer representing number of seconds to wait before sending data.
         """
-        sec_to_ms = 1000
-        data_rate = data_rate * sec_to_ms
-        battery_data_rate = battery_data_rate * sec_to_ms
-
-        self.status_led.set_state(WmState.ConnectingToMqtt)
-        sub_topics = [self.sub_start_topic, self.sub_stop_topic]
-        await self.mqtt.connect_and_subscribe(sub_topics, self.sub_cb)
-
-        # TODO: Publish battery voltage continuously while idle.
-        # Right now, will only publish once until logging starts.
-        if self.battery is not None:
-            battery_voltage = self.battery.read()
-            self.mqtt.publish(
-                self.battery_topic, ujson.dumps(battery_voltage), retain=True
-            )
-
+        secs_to_ms = 1000
+        interval *= secs_to_ms
         # get millisecond counter and initialise to some previous time to start data publication immediately
-        prev_data_sent = time.ticks_ms() - data_rate
-        prev_battery_read = time.ticks_ms()
+        prev_data_sent = time.ticks_ms() - interval
 
         while True:
             await self.wait_for_start()
 
             # Compute the time difference since the last sensor data was read
             time_taken = time.ticks_diff(time.ticks_ms(), prev_data_sent)
-            await asyncio.sleep_ms(data_rate - time_taken)
+            await asyncio.sleep_ms(interval - time_taken)
             prev_data_sent = time.ticks_ms()
 
             # Get and publish sensor data
@@ -136,14 +142,21 @@ class WirelessModule:
             self.mqtt.publish(self.pub_data_topic, ujson.dumps(sensor_data))
             print("MQTT data sent: {} on {}".format(sensor_data, self.pub_data_topic))
 
-            # Publish the battery voltage of this wireless module if the given delay (refer to `battery_data_rate`)
-            # has elapsed
-            ms_since_battery_read = time.ticks_diff(time.ticks_ms(), prev_battery_read)
-            if ms_since_battery_read >= battery_data_rate and self.battery is not None:
-                battery_voltage = self.battery.read()
-                self.mqtt.publish(
-                    self.battery_topic, ujson.dumps(battery_voltage), retain=True
-                )
-                prev_battery_read = time.ticks_ms()
-
             self.mqtt.check_for_message()
+
+    async def run(self, data_interval=1, battery_data_interval=5):
+        """
+        Start running the wireless module. Connects to MQTT and starts the data and battery loops.
+        :param data_interval: Integer representing number of seconds to wait before sending data.
+        :param battery_interval: Integer representing number of seconds to wait before sending battery voltage data
+        """
+        # Start publishing battery data straight away
+        asyncio.create_task(self.start_battery_loop(battery_data_interval))
+
+        # Attempt to connect to MQTT (will block until successful)
+        self.status_led.set_state(WmState.ConnectingToMqtt)
+        sub_topics = [self.sub_start_topic, self.sub_stop_topic]
+        await self.mqtt.connect_and_subscribe(sub_topics, self.sub_cb)
+
+        # Start the main publishing loop
+        asyncio.create_task(self.start_data_loop(data_interval))

--- a/wireless_modules/wireless_module.py
+++ b/wireless_modules/wireless_module.py
@@ -107,7 +107,7 @@ class WirelessModule:
         battery_data_rate = battery_data_rate * sec_to_ms
 
         sub_topics = [self.sub_start_topic, self.sub_stop_topic]
-        self.mqtt.connect_and_subscribe(sub_topics, self.sub_cb)
+        await self.mqtt.connect_and_subscribe(sub_topics, self.sub_cb)
 
         # TODO: Publish battery voltage continuously while idle.
         # Right now, will only publish once until logging starts.

--- a/wireless_modules/wireless_module.py
+++ b/wireless_modules/wireless_module.py
@@ -106,6 +106,7 @@ class WirelessModule:
         data_rate = data_rate * sec_to_ms
         battery_data_rate = battery_data_rate * sec_to_ms
 
+        self.status_led.set_state(WmState.ConnectingToMqtt)
         sub_topics = [self.sub_start_topic, self.sub_stop_topic]
         await self.mqtt.connect_and_subscribe(sub_topics, self.sub_cb)
 

--- a/wireless_modules/wireless_module.py
+++ b/wireless_modules/wireless_module.py
@@ -2,6 +2,7 @@ import uasyncio as asyncio
 import machine
 import ubinascii
 import ujson
+import sys
 import time
 
 from mqtt_client import Client
@@ -42,6 +43,21 @@ class WirelessModule:
 
         self.battery = battery_reader
         self.status_led = status_led
+
+        asyncio.get_event_loop().set_exception_handler(self.error_handler)
+
+    def error_handler(self, _loop, context):
+        self.status_led.set_state(WmState.Error)
+        print("An error occured in a uasyncio task!")
+        print(context["message"])
+        sys.print_exception(context["exception"])
+
+        # FIXME: A nicer solution would be to restart all running tasks rather than reset
+
+        print("Resetting in 5 seconds...")
+
+        time.sleep(5)
+        machine.reset()
 
     def add_sensors(self, sensor_arr):
         """


### PR DESCRIPTION
## Description

This PR adds code to control the WM's status LED. The status LED basically indicates what state the WM is in, e.g. connecting to MQTT broker or publishing data.

The status LED can be any of the 8 colour combinations made by having each of red, green and blue on or off. We could use PWM to allow many more colours but we probably don't want to have colours that are too similar, so this is fine for now (i.e. less work for me). The LED can also be blinking or solid. Take care that the LED cannot blink during blocking operations, I've made sure that this doesn't occur in the current implementation.

You can see the pre-defined LED states in `status_led.py`. I'll make a guide on notion for using the back WM shortly, which will include this information in a more reader-friendly manner.

Also changed in this PR:
- Battery and data publishing loops are now in their own `uasyncio` tasks, so that they run fully independently and don't block other tasks (e.g. LED blinking) from running when they're idle.
- The WM will now repeatedly try to connect to MQTT until it is unsuccessful. Previously it would just give up after one unsuccessful attempt.

## Screenshots

No screenshots, but here's the LED
![image](https://user-images.githubusercontent.com/17876556/133868484-f35731a6-e827-48f3-945e-1b6215a82d61.png)

## Steps to Test

If you happen to have the WM somehow, load the code with
```bash
cd wireless_modules/back_module
./upload.sh /dev/ttyUSB0 # substitute correct device
```

then reboot the WM. You should observe statuses as in `status_led.py`.