### PR TITLE
Update logger to use CSV_DIR path for env file

### DIFF
--- a/DAS/.env.example
+++ b/DAS/.env.example
@@ -1,0 +1,1 @@
+CSV_DIR="~/Documents/dashboard/server/data"

--- a/DAS/das/mqtt_wireless_logger.py
+++ b/DAS/das/mqtt_wireless_logger.py
@@ -25,7 +25,7 @@ GLOBAL_FILEPATH = os.path.dirname(__file__)
 
 # Global names
 TEMP_DIR = os.path.join(GLOBAL_FILEPATH, ".~temps")
-CSV_DIR = os.getenv('CSV_DIR') if os.getenv('CSV_DIR') else os.path.join(GLOBAL_FILEPATH, "../../../dashboard/server/data")
+CSV_DIR = os.getenv('CSV_DIR') or os.path.join(GLOBAL_FILEPATH, "csv_date")
 
 parser = argparse.ArgumentParser(
     description='MQTT wireless logger',

--- a/DAS/das/mqtt_wireless_logger.py
+++ b/DAS/das/mqtt_wireless_logger.py
@@ -1,5 +1,6 @@
 import paho.mqtt.client as mqtt
 import os
+from dotenv import load_dotenv
 import pandas as pd
 from datetime import datetime
 import argparse
@@ -10,6 +11,8 @@ from mhp import topics
 
 from das.utils import DataToTempCSV
 
+
+load_dotenv()
 
 # Global dicts to store state
 # Dict structure is {<module_id_str> : <data>}
@@ -22,7 +25,7 @@ GLOBAL_FILEPATH = os.path.dirname(__file__)
 
 # Global names
 TEMP_DIR = os.path.join(GLOBAL_FILEPATH, ".~temps")
-CSV_DIR = os.path.join(GLOBAL_FILEPATH, "../../../dashboard/server/data")
+CSV_DIR = os.getenv('CSV_DIR') if os.getenv('CSV_DIR') else os.path.join(GLOBAL_FILEPATH, "../../../dashboard/server/data")
 
 parser = argparse.ArgumentParser(
     description='MQTT wireless logger',
@@ -70,7 +73,7 @@ def on_message(client, userdata, msg):
         stop_recording(module_id_str)
 
     # Record data (battery, low-battery and sensor data)
-    elif is_recording[module_id_str]:
+    elif is_recording.get(module_id_str):
         DataToTempCSV(
             msg, module_start_time[module_id_str],
             module_id_str, module_id_num, TEMP_DIR)

--- a/DAS/poetry.lock
+++ b/DAS/poetry.lock
@@ -23,10 +23,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
 
 [[package]]
 name = "colorama"
@@ -46,6 +46,23 @@ python-versions = "*"
 
 [package.dependencies]
 six = "*"
+
+[[package]]
+name = "importlib-metadata"
+version = "4.10.1"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+perf = ["ipython"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -86,7 +103,6 @@ description = "Common repository containing all MHP python scripts"
 category = "main"
 optional = false
 python-versions = "^3.6"
-develop = false
 
 [package.dependencies]
 argparse = "^1.4.0"
@@ -162,9 +178,12 @@ category = "dev"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
 [package.extras]
-testing = ["pytest", "pytest-benchmark"]
 dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "py"
@@ -194,6 +213,7 @@ python-versions = ">=3.6"
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -213,6 +233,17 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-dotenv"
+version = "0.19.2"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pytz"
@@ -250,6 +281,14 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "typing-extensions"
+version = "4.0.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "urllib3"
 version = "1.26.6"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -260,12 +299,24 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+
+[[package]]
+name = "zipp"
+version = "3.7.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.8"
-content-hash = "71bcf6268873ba7f5e94eaf45387bb77a1d0f397782b7c73afdde63453c7f445"
+python-versions = "^3.7"
+content-hash = "f6cbc74aa3051616548dc60504211f8107e32317b3fc3c5ada1e757e3b7de69b"
 
 [metadata.files]
 argparse = [
@@ -287,6 +338,10 @@ colorama = [
 cycler = [
     {file = "cycler-0.10.0-py2.py3-none-any.whl", hash = "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d"},
     {file = "cycler-0.10.0.tar.gz", hash = "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-4.10.1-py3-none-any.whl", hash = "sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6"},
+    {file = "importlib_metadata-4.10.1.tar.gz", hash = "sha256:951f0d8a5b7260e9db5e41d429285b5f451e928479f19d80818878527d36e95e"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -497,6 +552,10 @@ python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
+python-dotenv = [
+    {file = "python-dotenv-0.19.2.tar.gz", hash = "sha256:a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f"},
+    {file = "python_dotenv-0.19.2-py2.py3-none-any.whl", hash = "sha256:32b2bdc1873fd3a3c346da1c6db83d0053c3c62f28f1f38516070c4c8971b1d3"},
+]
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
     {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
@@ -530,7 +589,15 @@ toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
+typing-extensions = [
+    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
+    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
+]
 urllib3 = [
     {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
     {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
+]
+zipp = [
+    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
+    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
 ]

--- a/DAS/pyproject.toml
+++ b/DAS/pyproject.toml
@@ -11,6 +11,7 @@ urllib3 = "^1.25.9"
 pandas = "^1.0.3"
 argparse = "^1.4.0"
 mhp = {git = "git@github.com:monash-human-power/common.git", rev = "202012.9"}
+python-dotenv = "^0.19.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"


### PR DESCRIPTION
## Description

This PR updates `mqtt_wireless_logger.py` to find the `CSV_DIR` path in a `.env` file if provided. The `CSV_DIR` is where the csv files containing WM data are stored.

Also fixed a bug where the code crashed when the WM is sent a start and stop message but the WM didn't publish anything (possible when the module is not powered up).

## Screenshots

N/A

## Steps to Test

1) Add `CSV_DIR` variable in `.env` file and run `python mqtt_wireless_logger.py` in poetry shell to check that the script is storing data in the provided path.
2) Use `das/V3_fake_module.py` to run fake data for the logger to store.
