### PR TITLE
Get ANT+ working

### DIFF
--- a/ant_plus_sensor/README.md
+++ b/ant_plus_sensor/README.md
@@ -5,16 +5,29 @@
 ## **[Ant-Plus Logger.js](https://github.com/monash-human-power/data-acquisition-system/blob/master/ant_plus_sensor/ant_plus_logger.js)**
 `ant_plus_logger.js` is the only way we can communicate to ant+ devices. It serves as the middle-man between the ANT+ sensors and the DAS MQTT broker. It allows the sensors to show up as a virtual wireless sensor module.
 
-## **Getting Started**
+## Getting Started
 
 ### Setting up node.js libraries
 To install the necessary libraries for node.js you may need to manually install them instead of running `npm install`.
 
 Run the script with `node ant_plus_logger.js`.
 
-To start this script automatically, see [the services README.md](/services/README.md).
+Sometimes, root permissions are required to connect to the USB dongle, so `sudo` may be required.
 
-## **Legacy Code**
+## Deployment
+
+To start this script automatically, follow the instructions in [the services README.md](/services/README.md).
+
+You will also need to ensure the default `pi` user has permissions to access the ANT+ dongle without `sudo`. Create the following file in `/etc/udev/rules.d/50-antplus.rules` and reboot:
+
+```
+# Allow access to ANT+ USB without sudo
+# https://www.xmodulo.com/change-usb-device-permission-linux.html
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0fcf", ATTRS{idProduct}=="1008", GROUP="users", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0fcf", ATTRS{idProduct}=="1009", GROUP="users", MODE="0666"
+```
+
+## Legacy Code
 + Teensy serial communication with the Ant+ can be found [here](https://github.com/monash-human-power/data-acquisition-system/blob/v2/Raspi/DAS.js)
 
 + Old Teensy scripts for collecting data can be found [here](https://github.com/monash-human-power/data-acquisition-system/tree/v2/Teensy)

--- a/ant_plus_sensor/ant_plus_logger.js
+++ b/ant_plus_sensor/ant_plus_logger.js
@@ -160,20 +160,10 @@ async function heartRateConnect(antPlus) {
     if (isRecording) {
       const power = Math.round(powerAverage.average() * 100) / 100;
       const payload = {
-        'module-id': moduleID,
         sensors: [
-          {
-            type: 'power',
-            value: power,
-          },
-          {
-            type: 'cadence',
-            value: cadence,
-          },
-          {
-            type: 'heartRate',
-            value: heartRate,
-          },
+          ...(power ? [{ type: 'power', value: power }] : []),
+          ...(cadence ? [{ type: 'cadence', value: cadence }] : []),
+          ...(heartRate ? [{ type: 'heartRate', value: heartRate }] : []),
         ],
       };
       const data = JSON.stringify(payload);


### PR DESCRIPTION
## Description

Kind of a misc. PR
- Document the permission requirements to get the ant plus sensor working
- Update the MQTT message format to not include module ID or null fields (i.e. that sensor has not connected) so that the dashboard type validation passes

## Screenshots

n/a

## Steps to Test

Get an ANT+ dongle and a raspberry Pi, and after following the instructions in the README, confirm that the script can connect to the ANT+ dongle.
