### PR TITLE
Wait before starting ant+ service

### DIFF
--- a/services/ant-plus.service
+++ b/services/ant-plus.service
@@ -5,5 +5,7 @@ Description=MHP ANT+ mock wireless module
 WantedBy=default.target
 
 [Service]
+# ANT+ dongle doesn't seem to work if we start too soon after boot
+ExecStartPre=/bin/sleep 20
 Restart=on-failure
 ExecStart=/bin/node ant_plus_logger


### PR DESCRIPTION
## Description

The ANT+ service required a restart after being started automatically by `systemd`. Apparently, it doesn't want to work if started immediately after boot. For the time being, waiting 20 seconds fixes the issue.

## Screenshots

n/a

## Steps to Test

Run this branch on a display. Ensure that no manual intervention is required to make ANT+ work after booting.
