### PR TITLE
Implement V3 start topic for WM and ant+ logger

### DIFF
--- a/ant_plus_sensor/ant_plus_logger.js
+++ b/ant_plus_sensor/ant_plus_logger.js
@@ -40,8 +40,6 @@ const args = argumentParser.parseArgs();
 const { id: moduleID, host: mqttAddress, rate } = args;
 winston.info(`Wireless module ID: ${moduleID}`);
 
-// const startTopic = `/v3/wireless_module/${moduleID}/start`;
-// const stopTopic = `/v3/wireless_module/${moduleID}/stop`;
 const v3StartTopic = 'v3/start';
 const dataTopic = `/v3/wireless_module/${moduleID}/data`;
 const statusTopic = `/v3/wireless_module/${moduleID}/status`;
@@ -168,25 +166,6 @@ async function heartRateConnect(antPlus) {
   // Announce we're online once ANT+ stick is also connected
   mqttClient.publish(statusTopic, JSON.stringify(onlineMsg), { retain: true });
 
-  // mqttClient.subscribe([startTopic, stopTopic]);
-  // mqttClient.on('message', (topic) => {
-  //   winston.info(`Topic fired: ${topic}`);
-  //   switch (topic) {
-  //     case startTopic:
-  //       isRecording = true;
-  //       distance = 0;
-  //       startWheelRevolutions = null;
-  //       winston.info('Start publishing data');
-  //       break;
-  //     case stopTopic:
-  //       isRecording = false;
-  //       winston.info('Stop publishing data');
-  //       break;
-  //     default:
-  //       winston.error(`Unexpected topic: ${topic}`);
-  //       break;
-  //   }
-  // });
   mqttClient.subscribe(v3StartTopic);
   mqttClient.on('message', (topic, payload) => {
     winston.info(`Topic fired: ${topic}`);

--- a/ant_plus_sensor/ant_plus_logger.js
+++ b/ant_plus_sensor/ant_plus_logger.js
@@ -40,8 +40,9 @@ const args = argumentParser.parseArgs();
 const { id: moduleID, host: mqttAddress, rate } = args;
 winston.info(`Wireless module ID: ${moduleID}`);
 
-const startTopic = `/v3/wireless_module/${moduleID}/start`;
-const stopTopic = `/v3/wireless_module/${moduleID}/stop`;
+// const startTopic = `/v3/wireless_module/${moduleID}/start`;
+// const stopTopic = `/v3/wireless_module/${moduleID}/stop`;
+const v3StartTopic = 'v3/start';
 const dataTopic = `/v3/wireless_module/${moduleID}/data`;
 const statusTopic = `/v3/wireless_module/${moduleID}/status`;
 
@@ -167,23 +168,46 @@ async function heartRateConnect(antPlus) {
   // Announce we're online once ANT+ stick is also connected
   mqttClient.publish(statusTopic, JSON.stringify(onlineMsg), { retain: true });
 
-  mqttClient.subscribe([startTopic, stopTopic]);
-  mqttClient.on('message', (topic) => {
+  // mqttClient.subscribe([startTopic, stopTopic]);
+  // mqttClient.on('message', (topic) => {
+  //   winston.info(`Topic fired: ${topic}`);
+  //   switch (topic) {
+  //     case startTopic:
+  //       isRecording = true;
+  //       distance = 0;
+  //       startWheelRevolutions = null;
+  //       winston.info('Start publishing data');
+  //       break;
+  //     case stopTopic:
+  //       isRecording = false;
+  //       winston.info('Stop publishing data');
+  //       break;
+  //     default:
+  //       winston.error(`Unexpected topic: ${topic}`);
+  //       break;
+  //   }
+  // });
+  mqttClient.subscribe(v3StartTopic);
+  mqttClient.on('message', (topic, payload) => {
     winston.info(`Topic fired: ${topic}`);
-    switch (topic) {
-      case startTopic:
+
+    if (topic === v3StartTopic) {
+      const msg = JSON.parse(payload);
+      winston.info(
+        `Received data from topic ${topic}: ${JSON.stringify(msg.start)}.`,
+      );
+
+      if (msg.start) {
         isRecording = true;
         distance = 0;
         startWheelRevolutions = null;
         winston.info('Start publishing data');
-        break;
-      case stopTopic:
+      } else {
         isRecording = false;
         winston.info('Stop publishing data');
-        break;
-      default:
-        winston.error(`Unexpected topic: ${topic}`);
-        break;
+      }
+    } else {
+      winston.error(`Unexpected topic: ${topic}`);
     }
   });
 

--- a/ant_plus_sensor/ant_plus_logger.js
+++ b/ant_plus_sensor/ant_plus_logger.js
@@ -172,9 +172,6 @@ async function heartRateConnect(antPlus) {
 
     if (topic === v3StartTopic) {
       const msg = JSON.parse(payload);
-      winston.info(
-        `Received data from topic ${topic}: ${JSON.stringify(msg.start)}.`,
-      );
 
       if (msg.start) {
         isRecording = true;

--- a/wireless_modules/wireless_module.py
+++ b/wireless_modules/wireless_module.py
@@ -100,7 +100,7 @@ class WirelessModule:
         #     self.start_publish = False
         if topic == self.v3_start:
             msg_data = json.loads(str(msg.payload.decode("utf-8")))
-            self.start_publish = msg_data
+            self.start_publish = msg_data["start"]
 
     async def start_battery_loop(self, interval):
         """

--- a/wireless_modules/wireless_module.py
+++ b/wireless_modules/wireless_module.py
@@ -96,8 +96,12 @@ class WirelessModule:
         if topic == self.v3_start:
             msg_data = json.loads(str(msg.decode("utf-8")))
             self.start_publish = msg_data["start"]
-            #Fix for changing LED when a true is retained
-            self.status_led.set_state(WmState.Publishing)
+
+            if msg_data["start"]:
+                self.status_led.set_state(WmState.Publishing)
+            else:
+                self.status_led.set_state(WmState.Idle)
+
 
     async def start_battery_loop(self, interval):
         """

--- a/wireless_modules/wireless_module.py
+++ b/wireless_modules/wireless_module.py
@@ -99,7 +99,7 @@ class WirelessModule:
         # elif topic == self.sub_stop_topic:
         #     self.start_publish = False
         if topic == self.v3_start:
-            msg_data = json.loads(str(msg.payload.decode("utf-8")))
+            msg_data = json.loads(str(msg.decode("utf-8")))
             self.start_publish = msg_data["start"]
 
     async def start_battery_loop(self, interval):

--- a/wireless_modules/wireless_module.py
+++ b/wireless_modules/wireless_module.py
@@ -96,6 +96,8 @@ class WirelessModule:
         if topic == self.v3_start:
             msg_data = json.loads(str(msg.decode("utf-8")))
             self.start_publish = msg_data["start"]
+            #Fix for changing LED when a true is retained
+            self.status_led.set_state(WmState.Publishing)
 
     async def start_battery_loop(self, interval):
         """
@@ -137,12 +139,7 @@ class WirelessModule:
 
             # Start message received, tell sensors to start
             for sensor in self.sensors:
-                sensor.on_start()
-        
-        #Fix for changing LED when a true is retained
-        if self.start_publish and self.status_led.state != WmState.Publishing:
-            self.status_led.set_state(WmState.Publishing)
-
+                sensor.on_start()         
 
     async def start_data_loop(self, interval):
         """

--- a/wireless_modules/wireless_module.py
+++ b/wireless_modules/wireless_module.py
@@ -2,6 +2,7 @@ import uasyncio as asyncio
 import machine
 import ubinascii
 import ujson
+import json
 import sys
 import time
 
@@ -32,8 +33,9 @@ class WirelessModule:
         self.pub_data_topic = b"/v3/wireless_module/{}/data".format(module_id)
         self.battery_topic = b"/v3/wireless_module/{}/battery".format(module_id)
 
-        self.sub_start_topic = b"/v3/wireless_module/{}/start".format(module_id)
-        self.sub_stop_topic = b"/v3/wireless_module/{}/stop".format(module_id)
+        #self.sub_start_topic = b"/v3/wireless_module/{}/start".format(module_id)
+        #self.sub_stop_topic = b"/v3/wireless_module/{}/stop".format(module_id)
+        self.v3_start = b"v3/start"
 
         self.status_topic = b"/v3/wireless_module/{}/status".format(module_id)
 
@@ -92,10 +94,13 @@ class WirelessModule:
         :param msg: The message received.
         """
         print("Successfully received message: ", msg, "on:", topic)
-        if topic == self.sub_start_topic:
-            self.start_publish = True
-        elif topic == self.sub_stop_topic:
-            self.start_publish = False
+        # if topic == self.sub_start_topic:
+        #     self.start_publish = True
+        # elif topic == self.sub_stop_topic:
+        #     self.start_publish = False
+        if topic == self.v3_start:
+            msg_data = json.loads(str(msg.payload.decode("utf-8")))
+            self.start_publish = msg_data
 
     async def start_battery_loop(self, interval):
         """
@@ -182,7 +187,8 @@ class WirelessModule:
 
         # Attempt to connect to MQTT (will block until successful)
         self.status_led.set_state(WmState.ConnectingToMqtt)
-        sub_topics = [self.sub_start_topic, self.sub_stop_topic]
+        #sub_topics = [self.sub_start_topic, self.sub_stop_topic]
+        sub_topics = [self.v3_start]
         await self.mqtt.connect_and_subscribe(sub_topics, self.sub_cb)
 
         # Start the main publishing loop


### PR DESCRIPTION
## Description
Implementing the new V3 start topic, **'v3/start**, to coincide with the V3 software system. This will be replacing the old start and stop topics. The new topic will have a structure of **{"start": true/false}**, where the Boolean value will denote whether any logging needs to start or not. There are 2 different components that have been altered the **Wireless Module** and **ANT+ Logger**, as such there are 2 different systems to test. 

## Screenshots
**ANT+ Screenshots**
Zadig Install:
![zadig install](https://user-images.githubusercontent.com/97724307/186158631-abefeb73-4460-4549-b0b6-e80792ba123b.PNG)

ANT+ Failed Connection:
![Inkedfailed connection](https://user-images.githubusercontent.com/97724307/186159500-f05de1ad-69db-4d61-8dcc-a56556f9440f.jpg)

ANT+ Successful Connection:
![Inkedsucessful connection](https://user-images.githubusercontent.com/97724307/186160032-5ef7c59a-b245-48e0-8977-1e2b64a9189c.jpg)

V3 Start True:
![Inkedv3start true](https://user-images.githubusercontent.com/97724307/186161307-d75e3f81-2972-4fe8-896b-6f362ffcd30c.jpg)

V3 Start False:
![Inkedv3start false](https://user-images.githubusercontent.com/97724307/186161402-015f9e73-e3a6-4c0d-a4f5-0e041d67cf59.jpg)


**Wireless Module Screenshots**
Putty Config:
![putty](https://user-images.githubusercontent.com/97724307/186164913-eefd3164-b79e-422d-b1e6-606c0008c1d4.PNG)

On Start:
![on start](https://user-images.githubusercontent.com/97724307/186165347-488d4c74-9895-41f3-ad4a-483ccc0badee.png)

WM True:
![v3 start true small](https://user-images.githubusercontent.com/97724307/186170882-0eb88499-acfe-4d3e-b582-040177e645ab.png)

WM False:


## Steps to Test
**Testing ANT+ Changes**
1. Switch to `.\ant_plus_sensor` (in a terminal).
2. Run 'npm install' to install necessary dependencies if you haven't already.
3. Ensure an ANT+ USB dongle is connected to your computer.
4. Windows users may need to install [Zadig](https://zadig.akeo.ie/) to read the dongle correctly. 
   - Install the latest version of Zadig.
   - Follow the USB installation steps.
   - See _Zadig Install,_ ensure that **libusb-win32**  is selected.

5.  In the terminal write `node ant_plus_logger.js`.
    - If code fails to find ant-plus USB and is stuck as in _ANT+ Failed Connection_.
    - May need to change instances of `GarminStick3` to `GarminStick2`.
    - These are found on lines 82, 88, 92, 106, 123, 139 (in `ant_plus_logger.js`).
    - A successful connection will look like _ANT+ Successful Connection_.
6.  Enure MQTT broker is started, then publish V3 start topics.
    - `mosquitto_pub -t 'v3/start' -m '{\"start\":true}'`, output should look like _V3 Start True_.
    - `mosquitto_pub -t 'v3/start' -m '{\"start\":false}'`, output should look like _V3 Start False_.
    - Note that Mac users don't need to use **\\"** to ensure the string literal is printed correctly.


**Testing Wireless Module Changes**
1. Connect the wireless module (WM) to your computer via micro-USB.
2. Check which port it is connected to and note it
    - Windows users can use **Device Manager** to check this.
3. Turn on the primary display.
4. Set up a mobile hotspot with the name `MHP_MobileNet` with the normal password (found on Notion).
    - Ensure your device also connects to this network.
5.  Flash the wireless module code using:
     -   `ampy -p port_WM_is_connected_to -b 115200 put path_to_wireless_module.py`.
     - Note that [ampy](https://pypi.org/project/adafruit-ampy/) does need to be installed for this, however any other means of flashing to WM is fine.
6. Once flashing is complete disconnect and then reconnect the micro-usb cable.  
7. Use [Putty](https://www.putty.org/) or similar software to analyze the output of the WM.
    - See _Putty Config_ for the configuration, note that you should use the port that you noted earlier.
    - On connect you should see a message similar to _On Start_.
8. Now publish the V3 start topics.
    - `mosquitto_pub -t 'v3/start' -m '{\"start\":true}' -h mhp-v3-primary.local`, the output should look like _WM True_.
    - `mosquitto_pub -t 'v3/start' -m '{\"start\":false}' -h mhp-v3-primary.local`, the output should look like _WM False_.
9. Once testing is over ensure that you flash the `master` version of `wireless_module.py`, using the same terminal command from earlier.    

**Notes**
- Sorry for the long PR, just need to make sure that nothing goes wrong with testing.
- Also sorry to Mac and Linux users, I'm not completely sure about what you'd need to use for testing.