### PR TITLE
Add crash alert cooldown as an argument

### DIFF
--- a/crash_alert/main_crash_alert.py
+++ b/crash_alert/main_crash_alert.py
@@ -37,6 +37,7 @@ class CrashAlertDriver():
         """
         parser = argparse.ArgumentParser()
         parser.add_argument("--host", type=str, default="localhost", help="ip address")
+        parser.add_argument("--cooldown", type=int, default=120, help="cooldown seconds")
         parsed_args = parser.parse_args(argv)
         return parsed_args
 
@@ -79,7 +80,7 @@ if __name__ == "__main__":
     slack_webhook = os.getenv("SLACK_WEBHOOK")
     ARGS = CrashAlertDriver.get_args()
     host = os.getenv("MQTT_HOST") or ARGS.host
-    cooldown = 10
+    cooldown = ARGS.cooldown
 
     CRASH_ALERT = CrashAlertDriver(host, cooldown, slack_webhook)
     CRASH_ALERT.start()


### PR DESCRIPTION
## Description

Adds the crash alert cooldown (minimum time in seconds between crash alert messages) as a parameter that can be passed in with the run command in the service file. If none is specified, the default cooldown is now 120secs.

## Screenshots

N/A

## Steps to Test

1. Create/activate your poetry environment using python 3.7. (i.e. `poetry env use 3.7`)
2. Spawn into the environment using `poetry shell`
3. Install the dependencies with `poetry install`
5. Run the main program using `python main_crash_alert.py`
6. In another window, publish to the MQTT channel:
```
# send a true
mosquitto_pub -t "/v3/wireless_module/3/crash_detection" -m '{"value": true}'
```
Once a true message is sent triggering the alert, if other true's are published, alerts should not appear until the cooldown of 2mins has passed.

7. To test the cooldown as a parameter, run the main program using `python main_crash_alert.py --cooldown "n"` where `n` is an integer representing some number of seconds.
8. Publish true messages again and alerts should only appear after `n` seconds have passed since the last one.

