### PR TITLE
commented out crash alert logging enabler

### DIFF
--- a/crash_alert/main_crash_alert.py
+++ b/crash_alert/main_crash_alert.py
@@ -63,7 +63,7 @@ class CrashAlertDriver():
         Starts the mqtt client.
         """
         self.client = mqtt.Client()
-        self.client.enable_logger()
+        # self.client.enable_logger()
         self.client.on_connect = self.on_connect 
         self.client.on_message = self.on_message 
         self.client.connect_async(self.host, self.port)


### PR DESCRIPTION
## Description

Commented out logging setting for crash alert client

## Steps to Test
install on primary then from terminal run (tail -f /var/log/syslog) via ssh
